### PR TITLE
Add seed so the lin library will compile if included

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@ lib_deps =
   https://github.com/pathfinder-for-autonomous-navigation/ChRt
   https://github.com/pathfinder-for-autonomous-navigation/CommonSoftware
   ; file:///Users/tanishqaggarwal/Documents/pan/repositories/CommonSoftware
-build_flags = -std=c++14 -Werror -Wall -D UNITY_INCLUDE_DOUBLE -O3
+build_flags = -std=c++14 -Werror -Wall -D UNITY_INCLUDE_DOUBLE -O3 -DLIN_RANDOM_SEED=358264
 src_filter = +<FCCode/> +<teensy.cpp>
 test_build_project_src = true
 


### PR DESCRIPTION
Forgot this is FSW. Talking about it in ADCS reminded me!

At the moment, if `#include <lin.hpp>` was included somewhere in the code FSW wouldn't compile.