### PR TITLE
Remove ChRt from build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,7 +7,6 @@ framework = arduino
 lib_deps =
   https://github.com/bblanchon/ArduinoJson
   https://github.com/pathfinder-for-autonomous-navigation/psim
-  https://github.com/pathfinder-for-autonomous-navigation/ChRt
   https://github.com/pathfinder-for-autonomous-navigation/CommonSoftware
   ; file:///Users/tanishqaggarwal/Documents/pan/repositories/CommonSoftware
 build_flags = -std=c++14 -Werror -Wall -D UNITY_INCLUDE_DOUBLE -O3 -DLIN_RANDOM_SEED=358264
@@ -102,7 +101,7 @@ lib_deps =
   https://github.com/bblanchon/ArduinoJson
   https://github.com/pathfinder-for-autonomous-navigation/CommonSoftware
   ; file:///Users/tanishqaggarwal/Documents/pan/repositories/CommonSoftware
-lib_ignore = ChRt, rwmutex, Drivers
+lib_ignore = rwmutex, Drivers
 lib_archive = false
 build_type = debug
 build_flags = -std=c++14 -Wall -Werror -D UNITY_INCLUDE_DOUBLE -lpthread -D DESKTOP -g -O0 --coverage
@@ -120,7 +119,7 @@ lib_deps =
   https://github.com/bblanchon/ArduinoJson
   https://github.com/pathfinder-for-autonomous-navigation/CommonSoftware
   ; file:///Users/tanishqaggarwal/Documents/pan/repositories/CommonSoftware
-lib_ignore = ChRt, rwmutex, Drivers
+lib_ignore = rwmutex, Drivers
 lib_archive = false
 build_flags = -std=c++14 -Wall -Werror -D UNITY_INCLUDE_DOUBLE -lpthread -D DESKTOP -O3
 test_build_project_src = true

--- a/platformio.ini
+++ b/platformio.ini
@@ -138,7 +138,7 @@ board = teensy35
 platform = ${teensy_cli.platform}
 framework = ${teensy_cli.framework}
 lib_deps = ${teensy_cli.lib_deps}
-build_flags = -std=c++14 -Wall -D UNITY_INCLUDE_DOUBLE -D PAN_LEADER
+build_flags = ${teensy_cli.build_flags} -D PAN_LEADER
 src_filter = +<adcs_test.cpp>
 lib_ignore = Piksi, SpikeAndHold
 upload_protocol = teensy-cli
@@ -149,7 +149,7 @@ board = teensy36
 platform = ${teensy_cli.platform}
 framework = ${teensy_cli.framework}
 lib_deps = ${teensy_cli.lib_deps}
-build_flags = -std=c++14 -Wall -D UNITY_INCLUDE_DOUBLE -D PAN_LEADER
+build_flags = ${teensy_cli.build_flags} -D PAN_LEADER
 src_filter = +<adcs_test.cpp>
 lib_ignore = Piksi, SpikeAndHold
 upload_protocol = teensy-cli
@@ -162,7 +162,7 @@ board = teensy36
 platform = ${teensy_cli.platform}
 framework = ${teensy_cli.framework}
 lib_deps = ${teensy_cli.lib_deps}
-build_flags = -std=c++14 -Wall -D UNITY_INCLUDE_DOUBLE
+build_flags = ${teensy_cli.build_flags} -D UNITY_INCLUDE_DOUBLE
 src_filter = +<teensy_stub.cpp>
 lib_ignore = Piksi, SpikeAndHold
 upload_protocol = teensy-cli
@@ -173,7 +173,7 @@ board = teensy36
 platform = ${teensy_cli.platform}
 framework = ${teensy_cli.framework}
 lib_deps = ${teensy_cli.lib_deps}
-build_flags = -std=c++14 -Wall -D UNITY_INCLUDE_DOUBLE
+build_flags = ${teensy_cli.build_flags} -D UNITY_INCLUDE_DOUBLE
 src_filter = +<teensy_stub.cpp>
 lib_ignore = Piksi, SpikeAndHold
 upload_protocol = teensy-cli
@@ -184,7 +184,7 @@ board = teensy36
 platform = ${teensy_cli.platform}
 framework = ${teensy_cli.framework}
 lib_deps = ${teensy_cli.lib_deps}
-build_flags = -std=c++14 -Wall -D UNITY_INCLUDE_DOUBLE
+build_flags = ${teensy_cli.build_flags} -D UNITY_INCLUDE_DOUBLE
 src_filter = +<teensy_stub.cpp>
 lib_ignore = Piksi, SpikeAndHold
 upload_protocol = teensy-cli
@@ -195,7 +195,7 @@ board = teensy35
 platform = ${teensy35_cli.platform}
 framework = ${teensy35_cli.framework}
 lib_deps = ${teensy35_cli.lib_deps}
-build_flags = -std=c++14 -Wall -D UNITY_INCLUDE_DOUBLE
+build_flags = ${teensy_cli.build_flags} -D UNITY_INCLUDE_DOUBLE
 src_filter = +<teensy_stub.cpp>
 lib_ignore = Piksi, SpikeAndHold
 upload_protocol = teensy-cli
@@ -206,7 +206,7 @@ board = teensy35
 platform = ${teensy35_cli.platform}
 framework = ${teensy35_cli.framework}
 lib_deps = ${teensy35_cli.lib_deps}
-build_flags = -std=c++14 -Wall -D UNITY_INCLUDE_DOUBLE
+build_flags = ${teensy_cli.build_flags} -D UNITY_INCLUDE_DOUBLE
 src_filter = +<teensy_stub.cpp>
 lib_ignore = Piksi, SpikeAndHold
 upload_protocol = teensy-cli
@@ -217,7 +217,7 @@ board = teensy35
 platform = ${teensy35_cli.platform}
 framework = ${teensy35_cli.framework}
 lib_deps = ${teensy35_cli.lib_deps}
-build_flags = -std=c++14 -Wall -D UNITY_INCLUDE_DOUBLE
+build_flags = ${teensy_cli.build_flags} -D UNITY_INCLUDE_DOUBLE
 src_filter = +<teensy_stub.cpp>
 lib_ignore = Piksi, SpikeAndHold
 upload_protocol = teensy-cli

--- a/src/teensy.cpp
+++ b/src/teensy.cpp
@@ -8,7 +8,6 @@
 #include "FCCode/MainControlLoop.hpp"
 #include <StateFieldRegistry.hpp>
 
-#include <ChRt.h>
 #include <core_pins.h>
 #include <wiring.h>
 

--- a/src/teensy.cpp
+++ b/src/teensy.cpp
@@ -25,7 +25,7 @@ void pan_system_setup() {
 // tests
 #ifndef UNIT_TEST
 void setup() {
-    chBegin(pan_system_setup);
+    pan_system_setup();
     while (true)
         ;
 }


### PR DESCRIPTION
Requires the corresponding PR on CommonSoftware to pass

Edit: corresponding PR was merged