### PR TITLE
Dev/remove smart pointers

### DIFF
--- a/lib/utils/ControlTask.hpp
+++ b/lib/utils/ControlTask.hpp
@@ -42,6 +42,11 @@ class ControlTask : protected debug_console {
     StateFieldRegistry& _registry;
 
     template<typename U>
+    bool add_internal_field(InternalStateField<U>& field) {
+        return _registry.add_internal_field(field.ptr());
+    }
+
+    template<typename U>
     bool add_readable_field(ReadableStateField<U>& field) {
         return _registry.add_readable_field(field.ptr());
     }
@@ -52,21 +57,30 @@ class ControlTask : protected debug_console {
     }
 
     template<typename U>
-    std::shared_ptr<ReadableStateField<U>> find_readable_field(const char* field, const char* file, const unsigned int line) {
-        auto field_ptr = std::static_pointer_cast<ReadableStateField<U>>(_registry.find_readable_field(field));
+    InternalStateField<U>* find_internal_field(const char* field, const char* file, const unsigned int line) {
+        auto field_ptr = _registry.find_internal_field(field);
         if (!field_ptr) { 
-            printf(debug_severity::error, "%s:%d: Readable field required is not present in state registry: %s\n", file, line, field);
+            printf(debug_severity::error, "%s:%d: Internal field required is not present in state registry: %s\n", file, line, field);
         }
-        return field_ptr;
+        return static_cast<InternalStateField<U>*>(field_ptr);
     }
 
     template<typename U>
-    std::shared_ptr<WritableStateField<U>> find_writable_field(const char* field, const char* file, const unsigned int line) {
-        auto field_ptr = std::static_pointer_cast<WritableStateField<U>>(_registry.find_writable_field(field));
+    ReadableStateField<U>* find_readable_field(const char* field, const char* file, const unsigned int line) {
+        auto field_ptr = _registry.find_readable_field(field);
+        if (!field_ptr) { 
+            printf(debug_severity::error, "%s:%d: Readable field required is not present in state registry: %s\n", file, line, field);
+        }
+        return static_cast<ReadableStateField<U>*>(field_ptr);
+    }
+
+    template<typename U>
+    WritableStateField<U>* find_writable_field(const char* field, const char* file, const unsigned int line) {
+        auto field_ptr = _registry.find_writable_field(field);
         if (!field_ptr) { 
             printf(debug_severity::error, "%s:%d: Writable field required is not present in state registry: %s\n", file, line, field);
         }
-        return field_ptr;
+        return static_cast<WritableStateField<U>*>(field_ptr);
     }
 };
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,6 +27,9 @@ board = teensy35
 extends = teensy_common
 board = teensy36
 
+[teensy_hootl]
+build_flags = ${teensy_common.build_flags} -D HOOTL
+
 [env:teensy35_cli_hootl]
 extends = teensy35_cli
 build_flags = ${teensy_common.build_flags} -D HOOTL -D PAN_LEADER

--- a/src/FCCode/ClockManager.cpp
+++ b/src/FCCode/ClockManager.cpp
@@ -5,7 +5,7 @@ ClockManager::ClockManager(StateFieldRegistry &registry,
     TimedControlTask<void>(registry, 0),
     control_cycle_start_time(),
     control_cycle_size(_control_cycle_size),
-    control_cycle_count_sr(0, 4294967295, 32),
+    control_cycle_count_sr(),
     control_cycle_count_f("pan.cycle_no", control_cycle_count_sr)
 {
     add_readable_field(control_cycle_count_f);

--- a/src/FCCode/DockingController.hpp
+++ b/src/FCCode/DockingController.hpp
@@ -30,7 +30,7 @@ class DockingController : public TimedControlTask<void> {
     Devices::DockingSystem& docksys;
 
     //shared pointer set by mission manager - tells control task to dock or undock motor
-    std::shared_ptr<WritableStateField<bool>> docking_config_cmd_fp;
+    WritableStateField<bool>* docking_config_cmd_fp;
 
     //state field returns whether or not the spacecraft are docked with one another
     Serializer<bool> docked_sr;

--- a/src/FCCode/MissionManager.cpp
+++ b/src/FCCode/MissionManager.cpp
@@ -2,30 +2,28 @@
 
 MissionManager::MissionManager(StateFieldRegistry& registry, unsigned int offset) :
     TimedControlTask<void>(registry, offset),
-    mission_mode_sr(0, 10, 4),
+    mission_mode_sr(10),
     mission_mode_f("pan.mode", mission_mode_sr),
     is_deployed_sr(),
     is_deployed_f("pan.deployed", is_deployed_sr),
-    sat_designation_sr(0, 2, 2),
+    sat_designation_sr(2),
     sat_designation_f("pan.sat_designation", sat_designation_sr)
 {
     control_cycle_count_fp = find_readable_field<unsigned int>("pan.cycle_no", __FILE__, __LINE__);
 
     add_writable_field(mission_mode_f);
     add_readable_field(is_deployed_f);
-    add_readable_field(sat_designation_f);
+    add_writable_field(sat_designation_f);
 
-    adcs_mode_fp = find_writable_field<unsigned int>("adcs.mode", __FILE__, __LINE__);
+    adcs_mode_fp = find_writable_field<unsigned char>("adcs.mode", __FILE__, __LINE__);
     adcs_cmd_attitude_fp = find_writable_field<f_quat_t>("adcs.cmd_attitude", __FILE__, __LINE__);
     adcs_ang_rate_fp = find_readable_field<float>("adcs.ang_rate", __FILE__, __LINE__);
     adcs_min_stable_ang_rate_fp = find_writable_field<float>("adcs.min_stable_ang_rate", __FILE__, __LINE__);
 
-    #ifdef DESKTOP
-        assert(adcs_mode_fp);
-        assert(adcs_cmd_attitude_fp);
-        assert(adcs_ang_rate_fp);
-        assert(adcs_min_stable_ang_rate_fp);
-    #endif
+    assert(adcs_mode_fp);
+    assert(adcs_cmd_attitude_fp);
+    assert(adcs_ang_rate_fp);
+    assert(adcs_min_stable_ang_rate_fp);
 
     // TODO change to startup.
     mission_mode_f.set(static_cast<unsigned int>(mission_mode_t::detumble));

--- a/src/FCCode/MissionManager.hpp
+++ b/src/FCCode/MissionManager.hpp
@@ -30,30 +30,30 @@ class MissionManager : public TimedControlTask<void> {
     /**
      * @brief Mode of ADCS system.
      **/
-    std::shared_ptr<WritableStateField<unsigned int>> adcs_mode_fp;
+    WritableStateField<unsigned char>* adcs_mode_fp;
     /**
      * @brief Currently commanded attitude of ADCS system.
      **/
-    std::shared_ptr<WritableStateField<f_quat_t>> adcs_cmd_attitude_fp;
+    WritableStateField<f_quat_t>* adcs_cmd_attitude_fp;
     /**
      * @brief Current angular rate of ADCS system in the body frame.
      **/
-    std::shared_ptr<ReadableStateField<float>> adcs_ang_rate_fp;
+    ReadableStateField<float>* adcs_ang_rate_fp;
     /**
      * @brief Minimum angular rate of ADCS system that can be considered "stable".
      **/
-    std::shared_ptr<WritableStateField<float>> adcs_min_stable_ang_rate_fp;
+    WritableStateField<float>* adcs_min_stable_ang_rate_fp;
 
     // Fields that control overall mission state.
     /**
      * @brief Control cycle count, provided by ClockManager.
      */
-    std::shared_ptr<ReadableStateField<unsigned int>> control_cycle_count_fp;
+    ReadableStateField<unsigned int>* control_cycle_count_fp;
     /**
      * @brief Current mission mode (see mission_mode_t.enum)
      */
-    Serializer<unsigned int> mission_mode_sr;
-    WritableStateField<unsigned int> mission_mode_f;
+    Serializer<unsigned char> mission_mode_sr;
+    WritableStateField<unsigned char> mission_mode_f;
     /**
      * @brief True if the satellite has exited the deployment timing phase.
      */
@@ -64,8 +64,8 @@ class MissionManager : public TimedControlTask<void> {
      * satellite is the leader satellite. 0 if the follower/leader designation
      * hasn't been made yet.
      */
-    Serializer<unsigned int> sat_designation_sr;
-    ReadableStateField<unsigned int> sat_designation_f;
+    Serializer<unsigned char> sat_designation_sr;
+    WritableStateField<unsigned char> sat_designation_f;
     
 };
 

--- a/test/StateFieldRegistryMock.hpp
+++ b/test/StateFieldRegistryMock.hpp
@@ -10,7 +10,45 @@
 class StateFieldRegistryMock : public StateFieldRegistry {
   public:
     StateFieldRegistryMock() : StateFieldRegistry() {}
-    
+
+    /**
+     * @brief Finds a internal state field of the given name.
+     */
+    template<typename T>
+    InternalStateField<T>* find_internal_field_t(const std::string& name) {
+        return static_cast<InternalStateField<T>*>(find_internal_field(name));
+    }
+
+    /**
+     * @brief Finds a readable state field of the given name.
+     */
+    template<typename T>
+    ReadableStateField<T>* find_readable_field_t(const std::string& name) {
+        return static_cast<ReadableStateField<T>*>(find_readable_field(name));
+    }
+
+    /**
+     * @brief Finds a writable state field of the given name.
+     */
+    template<typename T>
+    WritableStateField<T>* find_writable_field_t(const std::string& name) {
+        return static_cast<WritableStateField<T>*>(find_writable_field(name));
+    }
+
+    /**
+     * @brief Create an internal state field.
+     * 
+     * @param name Name of field.
+     * @return Pointer to field that was created.
+     */
+    template<typename T>
+    std::shared_ptr<InternalStateField<T>> create_internal_field(const std::string& name) {
+        auto field_ptr = std::make_shared<InternalStateField<T>>(name);
+        add_internal_field(field_ptr.get());
+        created_internal_fields.push_back(field_ptr);
+        return field_ptr;
+    }
+
     /**
      * @brief Create a readable state field for booleans, GPS times, and float/double quaternions.
      * 
@@ -19,18 +57,18 @@ class StateFieldRegistryMock : public StateFieldRegistry {
      */
     template<typename T>
     std::shared_ptr<ReadableStateField<T>> create_readable_field(const std::string& name) {
-        // Due to the definitions of the serializer constructors, this function can
-        // only be used to create state fields of specific types.
         static_assert(std::is_same<T, bool>::value ||
                       std::is_same<T, gps_time_t>::value ||
                       std::is_same<T, f_quat_t>::value ||
-                      std::is_same<T, d_quat_t>::value, 
-            "This function can only be used to create boolean, GPS-time, float-quaternion"
-            "or double-quaternion state fields.");
+                      std::is_same<T, d_quat_t>::value ||
+                      std::is_same<T, unsigned int>::value ||
+                      std::is_same<T, unsigned char>::value,
+            "Type argument for field creation with the given parameters was invalid.");
 
         Serializer<T> field_sr;
         auto field_ptr = std::make_shared<ReadableStateField<T>>(name, field_sr);
-        add_readable_field(field_ptr);
+        add_readable_field(field_ptr.get());
+        created_readable_fields.push_back(field_ptr);
         return field_ptr;
     }
 
@@ -42,18 +80,18 @@ class StateFieldRegistryMock : public StateFieldRegistry {
      */
     template<typename T>
     std::shared_ptr<WritableStateField<T>> create_writable_field(const std::string& name) {
-        // Due to the definitions of the serializer constructors, this function can
-        // only be used to create state fields of specific types.
         static_assert(std::is_same<T, bool>::value ||
                       std::is_same<T, gps_time_t>::value ||
                       std::is_same<T, f_quat_t>::value ||
-                      std::is_same<T, d_quat_t>::value,
-            "This function can only be used to create boolean, GPS-time, float-quaternion"
-            "or double-quaternion state fields.");
+                      std::is_same<T, d_quat_t>::value ||
+                      std::is_same<T, unsigned int>::value ||
+                      std::is_same<T, unsigned char>::value,
+            "Type argument for field creation with the given parameters was invalid.");
 
         Serializer<T> field_sr;
         auto field_ptr = std::make_shared<WritableStateField<T>>(name, field_sr);
-        add_writable_field(field_ptr);
+        add_writable_field(field_ptr.get());
+        created_writable_fields.push_back(field_ptr);
         return field_ptr;
     }
 
@@ -72,24 +110,24 @@ class StateFieldRegistryMock : public StateFieldRegistry {
     std::shared_ptr<ReadableStateField<T>> create_readable_field(const std::string& name, 
         T min, T max, size_t bitsize)
     {
-        // Due to the definitions of the serializer constructors, this function can
-        // only be used to create state fields of specific types.
         static_assert(std::is_same<T, signed int>::value ||
             std::is_same<T, unsigned int>::value ||
+            std::is_same<T, signed char>::value ||
+            std::is_same<T, unsigned char>::value ||
             std::is_same<T, float>::value ||
             std::is_same<T, double>::value,
-        "This function can only be used to create signed int, unsigned int, float or double"
-        "state fields.");
+            "Type argument for field creation with the given parameters was invalid.");
 
         Serializer<T> field_sr(min, max, bitsize);
         auto field_ptr = std::make_shared<ReadableStateField<T>>(name, field_sr);
-        add_readable_field(field_ptr);
+        add_readable_field(field_ptr.get());
+        created_readable_fields.push_back(field_ptr);
         return field_ptr;
     }
 
     /**
-     * @brief Create a writable field for signed/unsigned ints, and floats/doubles and add
-     * it to the registry.
+     * @brief Create a writable field for signed/unsigned ints, and floats/doubles and
+     * add it to the registry.
      * 
      * @tparam T Type of object.
      * @param name Name of field to create.
@@ -102,18 +140,80 @@ class StateFieldRegistryMock : public StateFieldRegistry {
     std::shared_ptr<WritableStateField<T>> create_writable_field(const std::string& name, 
         T min, T max, size_t bitsize)
     {
-        // Due to the definitions of the serializer constructors, this function can
-        // only be used to create state fields of specific types.
         static_assert(std::is_same<T, signed int>::value ||
             std::is_same<T, unsigned int>::value ||
+            std::is_same<T, signed char>::value ||
+            std::is_same<T, unsigned char>::value ||
             std::is_same<T, float>::value ||
             std::is_same<T, double>::value,
-        "This function can only be used to create signed int, unsigned int, float or double"
-        "state fields.");
+            "Type argument for field creation with the given parameters was invalid.");
 
         Serializer<T> field_sr(min, max, bitsize);
         auto field_ptr = std::make_shared<WritableStateField<T>>(name, field_sr);
+        add_writable_field(field_ptr.get());
+        created_writable_fields.push_back(field_ptr);
+        return field_ptr;
+    }
+
+    template<typename T>
+    std::shared_ptr<ReadableStateField<T>> create_readable_field(const std::string& name, 
+        T min, T max)
+    {
+        static_assert(std::is_same<T, signed int>::value ||
+            std::is_same<T, unsigned int>::value ||
+            std::is_same<T, signed char>::value ||
+            std::is_same<T, unsigned char>::value,
+            "Type argument for field creation with the given parameters was invalid.");
+
+        Serializer<T> field_sr(min, max);
+        auto field_ptr = std::make_shared<ReadableStateField<T>>(name, field_sr);
+        add_readable_field(field_ptr.get());
+        created_readable_fields.push_back(field_ptr);
+        return field_ptr;
+    }
+
+    template<typename T>
+    std::shared_ptr<WritableStateField<T>> create_writable_field(const std::string& name, 
+        T min, T max)
+    {
+        static_assert(std::is_same<T, signed int>::value ||
+            std::is_same<T, unsigned int>::value ||
+            std::is_same<T, signed char>::value ||
+            std::is_same<T, unsigned char>::value,
+            "Type argument for field creation with the given parameters was invalid.");
+
+        Serializer<T> field_sr(min, max);
+        auto field_ptr = std::make_shared<WritableStateField<T>>(name, field_sr);
         add_writable_field(field_ptr);
+        created_writable_fields.push_back(field_ptr);
+        return field_ptr;
+    }
+
+    template<typename T>
+    std::shared_ptr<ReadableStateField<T>> create_readable_field(const std::string& name, T max)
+    {
+        static_assert(std::is_same<T, unsigned int>::value ||
+                      std::is_same<T, unsigned char>::value,
+            "Type argument for field creation with the given parameters was invalid.");
+
+        Serializer<T> field_sr(max);
+        auto field_ptr = std::make_shared<ReadableStateField<T>>(name, field_sr);
+        add_readable_field(field_ptr.get());
+        created_readable_fields.push_back(field_ptr);
+        return field_ptr;
+    }
+
+    template<typename T>
+    std::shared_ptr<WritableStateField<T>> create_writable_field(const std::string& name, T max)
+    {
+        static_assert(std::is_same<T, unsigned int>::value ||
+                      std::is_same<T, unsigned char>::value,
+            "Type argument for field creation with the given parameters was invalid.");
+
+        Serializer<T> field_sr(max);
+        auto field_ptr = std::make_shared<WritableStateField<T>>(name, field_sr);
+        add_writable_field(field_ptr.get());
+        created_writable_fields.push_back(field_ptr);
         return field_ptr;
     }
 
@@ -132,15 +232,14 @@ class StateFieldRegistryMock : public StateFieldRegistry {
     std::shared_ptr<ReadableStateField<std::array<T,3>>> create_readable_vector_field(const std::string& name,
         T min, T max, size_t bitsize)
     {
-        // Due to the definitions of the serializer constructors, this function can
-        // only be used to create state fields of specific types.
         static_assert(std::is_same<T, float>::value ||
                       std::is_same<T, double>::value,
-        "This function can only be used to create float- or double-vector state fields.");
+            "Type argument for field creation with the given parameters was invalid.");
 
         Serializer<std::array<T, 3>> field_sr(min, max, bitsize);
         auto field_ptr = std::make_shared<ReadableStateField<std::array<T, 3>>>(name, field_sr);
-        add_readable_field(field_ptr);
+        add_readable_field(field_ptr.get());
+        created_readable_fields.push_back(field_ptr);
         return field_ptr;
     }
 
@@ -159,17 +258,37 @@ class StateFieldRegistryMock : public StateFieldRegistry {
     std::shared_ptr<WritableStateField<std::array<T, 3>>> create_writable_vector_field(const std::string& name,
         T min, T max, size_t bitsize)
     {
-        // Due to the definitions of the serializer constructors, this function can
-        // only be used to create state fields of specific types.
         static_assert(std::is_same<T, float>::value ||
                       std::is_same<T, double>::value,
-        "This function can only be used to create float- or double-vector state fields.");
+            "Type argument for field creation with the given parameters was invalid.");
 
         Serializer<std::array<T, 3>> field_sr(min, max, bitsize);
         auto field_ptr = std::make_shared<WritableStateField<std::array<T, 3>>>(name, field_sr);
-        add_writable_field(field_ptr);
+        add_writable_field(field_ptr.get());
+        created_writable_fields.push_back(field_ptr);
         return field_ptr;
     }
+
+    /**
+     * @brief Empty the registry.
+     */
+    void clear() {
+        internal_fields.clear();
+        readable_fields.clear();
+        writable_fields.clear();
+        created_internal_fields.clear();
+        created_readable_fields.clear();
+        created_writable_fields.clear();
+    }
+
+  private:
+    // Store pointers to all of the state fields that have been created, in order
+    // to prevent segmentation faults due to shared pointers going out of scope before a
+    // ControlTask has a chance to call find_readable_field().
+    
+    std::vector<std::shared_ptr<InternalStateFieldBase>> created_internal_fields;
+    std::vector<std::shared_ptr<ReadableStateFieldBase>> created_readable_fields;
+    std::vector<std::shared_ptr<WritableStateFieldBase>> created_writable_fields;
 };
 
 #endif

--- a/test/test_fsw_docking/test_fsw_docking.cpp
+++ b/test/test_fsw_docking/test_fsw_docking.cpp
@@ -12,9 +12,9 @@ class TestFixture {
 
     std::unique_ptr<DockingController> docking_controller;
 
-    std::shared_ptr<ReadableStateField<bool>>dock_config_fp;
-    std::shared_ptr<ReadableStateField<bool>>docked_fp;
-    std::shared_ptr<ReadableStateField<bool>>is_turning_fp;
+    ReadableStateField<bool>* dock_config_fp;
+    ReadableStateField<bool>* docked_fp;
+    ReadableStateField<bool>* is_turning_fp;
 
     TestFixture() : registry() {
         docking_config_cmd_fp = registry.create_writable_field<bool>("docksys.config_cmd");
@@ -22,17 +22,22 @@ class TestFixture {
 
         docking_controller = std::make_unique<DockingController>(registry, 0, docksys); 
 
-        docked_fp = std::static_pointer_cast<ReadableStateField<bool>>(registry.find_readable_field("docksys.docked"));
+        docked_fp = registry.find_readable_field_t<bool>("docksys.docked");
+        dock_config_fp = registry.find_readable_field_t<bool>("docksys.dock_config");
+        is_turning_fp = registry.find_readable_field_t<bool>("docksys.is_turning");
+
         docked_fp->set(false);
-        dock_config_fp = std::static_pointer_cast<ReadableStateField<bool>>(registry.find_readable_field("docksys.dock_config"));
         dock_config_fp->set(true);
-        is_turning_fp = std::static_pointer_cast<ReadableStateField<bool>>(registry.find_readable_field("docksys.is_turning"));
         is_turning_fp->set(false);
     }
 };
 
 void test_task_initialization() {
     TestFixture tf;
+    TEST_ASSERT_NOT_NULL(tf.docked_fp);
+    TEST_ASSERT_NOT_NULL(tf.dock_config_fp);
+    TEST_ASSERT_NOT_NULL(tf.is_turning_fp);
+
     TEST_ASSERT_EQUAL(false, tf.docking_config_cmd_fp->get());
     TEST_ASSERT_EQUAL(false, tf.docked_fp->get());
     TEST_ASSERT_EQUAL(true, tf.dock_config_fp->get());

--- a/test/test_fsw_mission_manager/test_mission_manager.cpp
+++ b/test/test_fsw_mission_manager/test_mission_manager.cpp
@@ -11,29 +11,34 @@ class TestFixture {
     StateFieldRegistryMock registry;
     // Input state fields to mission manager
     std::shared_ptr<WritableStateField<unsigned int>> cycle_no_fp;
-    std::shared_ptr<WritableStateField<unsigned int>> adcs_mode_fp;
+    std::shared_ptr<WritableStateField<unsigned char>> adcs_mode_fp;
     std::shared_ptr<WritableStateField<f_quat_t>> adcs_cmd_attitude_fp;
     std::shared_ptr<ReadableStateField<float>> adcs_ang_rate_fp;
     std::shared_ptr<WritableStateField<float>> adcs_min_stable_ang_rate_fp;
 
     std::unique_ptr<MissionManager> mission_manager;
     // Output state fields from mission manager
-    std::shared_ptr<WritableStateField<unsigned int>> mission_mode_fp;
+    WritableStateField<unsigned char>* mission_mode_fp;
+    WritableStateField<unsigned char>* sat_designation_fp;
 
     TestFixture() : registry() {
-        cycle_no_fp = registry.create_writable_field<unsigned int>("pan.cycle_no", 0, 4294967295, 32);
-        adcs_mode_fp = registry.create_writable_field<unsigned int>("adcs.mode", 0, 10, 4) ;
+        cycle_no_fp = registry.create_writable_field<unsigned int>("pan.cycle_no");
+        adcs_mode_fp = registry.create_writable_field<unsigned char>("adcs.mode", 10);
         adcs_cmd_attitude_fp = registry.create_writable_field<f_quat_t>("adcs.cmd_attitude");
         adcs_ang_rate_fp = registry.create_readable_field<float>("adcs.ang_rate", 0, 10, 4);
         adcs_min_stable_ang_rate_fp = registry.create_writable_field<float>("adcs.min_stable_ang_rate", 0, 10, 4);
         mission_manager = std::make_unique<MissionManager>(registry, 0);
 
-        mission_mode_fp = std::static_pointer_cast<WritableStateField<unsigned int>>(registry.find_writable_field("pan.mode"));
+        mission_mode_fp = registry.find_writable_field_t<unsigned char>("pan.mode");
+        sat_designation_fp = registry.find_writable_field_t<unsigned char>("pan.sat_designation");
     }
 };
 
 void test_valid_initialization() {
     TestFixture tf;
+
+    TEST_ASSERT_NOT_NULL(tf.mission_mode_fp);
+    TEST_ASSERT_NOT_NULL(tf.sat_designation_fp);
 }
 
 void test_dispatch_detumble() {

--- a/test/test_fsw_state_field_registry_mock/test_fsw_state_field_registry_mock.cpp
+++ b/test/test_fsw_state_field_registry_mock/test_fsw_state_field_registry_mock.cpp
@@ -128,11 +128,11 @@ void test_create_writable_field_args() {
 void test_create_readable_vector_field_args() {
     StateFieldRegistryMock registry;
 
-    registry.create_readable_vector_field<float>("foo", 0, 10, 4);
+    registry.create_readable_vector_field<float>("foo", 0, 10, 40);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo"));
     TEST_ASSERT_NULL(registry.find_writable_field("foo"));
 
-    registry.create_readable_vector_field<double>("foo2", 0, 10, 4);
+    registry.create_readable_vector_field<double>("foo2", 0, 10, 40);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo2"));
     TEST_ASSERT_NULL(registry.find_writable_field("foo2"));
 }
@@ -140,11 +140,11 @@ void test_create_readable_vector_field_args() {
 void test_create_writable_vector_field_args() {
     StateFieldRegistryMock registry;
 
-    registry.create_writable_vector_field<float>("foo", 0, 10, 4);
+    registry.create_writable_vector_field<float>("foo", 0, 10, 40);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo"));
     TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo"));
 
-    registry.create_writable_vector_field<double>("foo2", 0, 10, 4);
+    registry.create_writable_vector_field<double>("foo2", 0, 10, 40);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo2"));
     TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo2"));
 }

--- a/test/test_fsw_state_field_registry_mock/test_fsw_state_field_registry_mock.cpp
+++ b/test/test_fsw_state_field_registry_mock/test_fsw_state_field_registry_mock.cpp
@@ -7,25 +7,37 @@ void test_valid_initialization() {
 }
 
 /**
- * @brief Test create functions that don't require any arguments
+ * @brief Test creation of an internal state field.
+ */
+void test_create_internal_field() {
+    StateFieldRegistryMock registry;
+
+    registry.create_internal_field<bool>("foo");
+    TEST_ASSERT_NOT_NULL(registry.find_internal_field("foo"));
+    TEST_ASSERT_NULL(registry.find_readable_field("foo"));
+    TEST_ASSERT_NULL(registry.find_writable_field("foo"));
+}
+
+/**
+ * @brief Test creation functions that don't require any arguments
  * besides the name of the field.
  */
 void test_create_readable_field_noargs() {
     StateFieldRegistryMock registry;
 
-    auto foo_ptr = registry.create_readable_field<bool>("foo");
+    registry.create_readable_field<bool>("foo");
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo"));
     TEST_ASSERT_NULL(registry.find_writable_field("foo"));
 
-    auto foo_ptr2 = registry.create_readable_field<gps_time_t>("foo2");
+    registry.create_readable_field<gps_time_t>("foo2");
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo2"));
     TEST_ASSERT_NULL(registry.find_writable_field("foo2"));
 
-    auto foo_ptr3 = registry.create_readable_field<f_quat_t>("foo3");
+    registry.create_readable_field<f_quat_t>("foo3");
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo3"));
     TEST_ASSERT_NULL(registry.find_writable_field("foo3"));
 
-    auto foo_ptr4 = registry.create_readable_field<d_quat_t>("foo4");
+    registry.create_readable_field<d_quat_t>("foo4");
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo4"));
     TEST_ASSERT_NULL(registry.find_writable_field("foo4"));
 }
@@ -33,39 +45,51 @@ void test_create_readable_field_noargs() {
 void test_create_writable_field_noargs() {
     StateFieldRegistryMock registry;
 
-    auto foo_ptr = registry.create_writable_field<bool>("foo");
+    registry.create_writable_field<bool>("foo");
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo"));
     TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo"));
 
-    auto foo_ptr2 = registry.create_writable_field<gps_time_t>("foo2");
+    registry.create_writable_field<gps_time_t>("foo2");
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo2"));
     TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo2"));
 
-    auto foo_ptr3 = registry.create_writable_field<f_quat_t>("foo3");
+    registry.create_writable_field<f_quat_t>("foo3");
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo3"));
     TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo3"));
 
-    auto foo_ptr4 = registry.create_readable_field<d_quat_t>("foo4");
+    registry.create_readable_field<d_quat_t>("foo4");
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo4"));
     TEST_ASSERT_NULL(registry.find_writable_field("foo4"));
 }
 
+/**
+ * @brief Test create functions that require numerical arguments
+ * about serialization parameters.
+ */
 void test_create_readable_field_args() {
     StateFieldRegistryMock registry;
 
-    auto foo_ptr = registry.create_readable_field<signed int>("foo", -1, 10, 4);
+    registry.create_readable_field<signed int>("foo", -1, 10, 4);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo"));
     TEST_ASSERT_NULL(registry.find_writable_field("foo"));
 
-    auto foo_ptr2 = registry.create_readable_field<unsigned int>("foo2", 1, 10, 4);
+    registry.create_readable_field<unsigned int>("foo2", 1, 10, 4);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo2"));
     TEST_ASSERT_NULL(registry.find_writable_field("foo2"));
 
-    auto foo_ptr3 = registry.create_readable_field<float>("foo3", 2.2, 10, 4);
+    registry.create_readable_field<signed char>("foo5", -1, 10, 4);
+    TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo5"));
+    TEST_ASSERT_NULL(registry.find_writable_field("foo5"));
+
+    registry.create_readable_field<unsigned char>("foo6", 1, 10, 4);
+    TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo6"));
+    TEST_ASSERT_NULL(registry.find_writable_field("foo6"));
+
+    registry.create_readable_field<float>("foo3", 2.2, 10, 4);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo3"));
     TEST_ASSERT_NULL(registry.find_writable_field("foo3"));
 
-    auto foo_ptr4 = registry.create_readable_field<double>("foo4", 2.2, 10, 4);
+    registry.create_readable_field<double>("foo4", 2.2, 10, 4);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo4"));
     TEST_ASSERT_NULL(registry.find_writable_field("foo4"));
 }
@@ -73,31 +97,42 @@ void test_create_readable_field_args() {
 void test_create_writable_field_args() {
     StateFieldRegistryMock registry;
 
-    auto foo_ptr = registry.create_writable_field<signed int>("foo", -1, 10, 4);
+    registry.create_writable_field<signed int>("foo", -1, 10, 4);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo"));
     TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo"));
 
-    auto foo_ptr2 = registry.create_writable_field<unsigned int>("foo2", 1, 10, 4);
+    registry.create_writable_field<unsigned int>("foo2", 1, 10, 4);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo2"));
     TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo2"));
 
-    auto foo_ptr3 = registry.create_writable_field<float>("foo3", 2.2, 10, 4);
+    registry.create_writable_field<signed char>("foo5", -1, 10, 4);
+    TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo5"));
+    TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo5"));
+
+    registry.create_writable_field<unsigned char>("foo6", 1, 10, 4);
+    TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo6"));
+    TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo6"));
+
+    registry.create_writable_field<float>("foo3", 2.2, 10, 4);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo3"));
     TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo3"));
 
-    auto foo_ptr4 = registry.create_writable_field<double>("foo4", 2.2, 10, 4);
+    registry.create_writable_field<double>("foo4", 2.2, 10, 4);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo4"));
     TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo4"));
 }
 
+/**
+ * @brief Test vector state field creation functions.
+ */
 void test_create_readable_vector_field_args() {
     StateFieldRegistryMock registry;
 
-    auto foo_ptr = registry.create_readable_vector_field<float>("foo", 0, 10, 4);
+    registry.create_readable_vector_field<float>("foo", 0, 10, 4);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo"));
     TEST_ASSERT_NULL(registry.find_writable_field("foo"));
 
-    auto foo_ptr2 = registry.create_readable_vector_field<double>("foo2", 0, 10, 4);
+    registry.create_readable_vector_field<double>("foo2", 0, 10, 4);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo2"));
     TEST_ASSERT_NULL(registry.find_writable_field("foo2"));
 }
@@ -105,24 +140,48 @@ void test_create_readable_vector_field_args() {
 void test_create_writable_vector_field_args() {
     StateFieldRegistryMock registry;
 
-    auto foo_ptr = registry.create_writable_vector_field<float>("foo", 0, 10, 4);
+    registry.create_writable_vector_field<float>("foo", 0, 10, 4);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo"));
     TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo"));
 
-    auto foo_ptr2 = registry.create_writable_vector_field<double>("foo2", 0, 10, 4);
+    registry.create_writable_vector_field<double>("foo2", 0, 10, 4);
     TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo2"));
     TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo2"));
+}
+
+/**
+ * @brief Test clearing the registry.
+ */
+void test_clear() {
+    StateFieldRegistryMock registry;
+
+    registry.create_writable_field<unsigned int>("foo", 0, 10, 4);
+    TEST_ASSERT_NOT_NULL(registry.find_writable_field("foo"));
+
+    registry.create_readable_field<unsigned int>("foo2", 0, 10, 4);
+    TEST_ASSERT_NOT_NULL(registry.find_readable_field("foo2"));
+
+    registry.create_internal_field<unsigned int>("foo3");
+    TEST_ASSERT_NOT_NULL(registry.find_internal_field("foo3"));
+
+    registry.clear();
+    TEST_ASSERT_NULL(registry.find_internal_field("foo"));
+    TEST_ASSERT_NULL(registry.find_readable_field("foo2"));
+    TEST_ASSERT_NULL(registry.find_readable_field("foo3"));
+    TEST_ASSERT_NULL(registry.find_writable_field("foo3"));
 }
 
 int test_state_field_registry_mock() {
     UNITY_BEGIN();
     RUN_TEST(test_valid_initialization);
+    RUN_TEST(test_create_internal_field);
     RUN_TEST(test_create_readable_field_noargs);
     RUN_TEST(test_create_writable_field_noargs);
     RUN_TEST(test_create_readable_field_args);
     RUN_TEST(test_create_writable_field_args);
     RUN_TEST(test_create_readable_vector_field_args);
     RUN_TEST(test_create_writable_vector_field_args);
+    RUN_TEST(test_clear);
     return UNITY_END();
 }
 


### PR DESCRIPTION
This gets rid of the use of shared pointers on the Flight Software side, and adds helpful utilities to StateFieldRegistryMock for internal state fields