### PR TITLE
Dev/piksi controller v2

### DIFF
--- a/hardware_test_envs.ini
+++ b/hardware_test_envs.ini
@@ -6,10 +6,9 @@
 platform = teensy
 framework = arduino
 lib_deps =
-  i2c_t3
   https://github.com/pathfinder-for-autonomous-navigation/psim
   https://github.com/pathfinder-for-autonomous-navigation/CommonSoftware
-build_flags = -std=c++14 -Werror -Wall -D UNITY_INCLUDE_DOUBLE -O3 -DLIN_RANDOM_SEED=358264 -D PAN_LEADER
+build_flags = -std=c++14 -Werror -Wall -D UNITY_INCLUDE_DOUBLE -O3 -DLIN_RANDOM_SEED=358264
 src_filter = +<teensy_stub.cpp>
 upload_protocol = teensy-cli
 test_build_project_src = true
@@ -39,6 +38,23 @@ test_filter = test_prop
 board = teensy36
 extends = hardware_common
 test_filter = test_prop
+
+##########
+# Piksi
+##########
+
+[env:test_piksi_func]
+board = teensy36
+extends = hardware_common
+build_flags = -D SERIAL4_RX_BUFFER_SIZE=1024 -D LIN_RANDOM_SEED
+test_filter = test_piksi_func
+
+[env:teensy_36_test_piksi]
+board = teensy36
+extends = hardware_common
+build_flags = -D SERIAL4_RX_BUFFER_SIZE=1024 -D LIN_RANDOM_SEED
+test_filter = test_piksi
+
 
 ##########
 # ADCS

--- a/lib/Drivers/Piksi.cpp
+++ b/lib/Drivers/Piksi.cpp
@@ -278,8 +278,8 @@ unsigned char Piksi::read_all() {
     if(bytes_available()){
         bool crc_error = false;
         while(bytes_available() && (micros() - initial_time < READ_ALL_LIMIT)){
-            int p_b_return = process_buffer();
-            if(p_b_return < 0)
+            //call process_buffer() to process data, and check if crc_error happened
+            if(process_buffer() < 0)
                 crc_error = true;
         }
 

--- a/lib/Drivers/Piksi.cpp
+++ b/lib/Drivers/Piksi.cpp
@@ -290,16 +290,16 @@ unsigned char Piksi::read_all() {
             clear_bytes();
             return 5;
         }
-  
-        if(_gps_time_update && _pos_ecef_update && _vel_ecef_update && !_baseline_ecef_update)
+        if(crc_error)
+            return 3;
+        else if(_gps_time_update && _pos_ecef_update && _vel_ecef_update && !_baseline_ecef_update)
+            //SPP
             return 0;
         else if(_gps_time_update && _pos_ecef_update && _vel_ecef_update && _baseline_ecef_update)
+            //Something RTK
             return 1;
-        else if(crc_error)
-            return 3;
         else
-            //error condition, perhaps serial data bad
-            //or time looped around
+            //no relevant callbacks or crc_errors -> NO_FIX
             return 2;
     }
     else

--- a/lib/Drivers/Piksi.cpp
+++ b/lib/Drivers/Piksi.cpp
@@ -417,7 +417,7 @@ void Piksi::_iar_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
 }
 void Piksi::_settings_read_resp_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
     Piksi *piksi = (Piksi *)context;
-    memcpy((u8 *)(&(piksi->_base_pos_ecef)), msg, sizeof(msg_settings_read_resp_t));
+    memcpy((u8 *)(&(piksi->_settings_read_resp)), msg, sizeof(msg_settings_read_resp_t));
 }
 void Piksi::_heartbeat_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
     Piksi *piksi = (Piksi *)context;

--- a/lib/Drivers/Piksi.cpp
+++ b/lib/Drivers/Piksi.cpp
@@ -1,7 +1,13 @@
-#ifndef DESKTOP
 #include "Piksi.hpp"
+#include <cstring>
+
+#ifndef DESKTOP
+#include <Arduino.h>
+#endif
 
 using namespace Devices;
+//using namespace std;
+
 
 // Initialize callback nodes so that C++ doesn't complain about them not being
 // defined.
@@ -19,11 +25,20 @@ sbp_msg_callbacks_node_t Piksi::_heartbeat_callback_node;
 sbp_msg_callbacks_node_t Piksi::_uart_state_callback_node;
 sbp_msg_callbacks_node_t Piksi::_user_data_callback_node;
 
+#ifndef DESKTOP
 Piksi::Piksi(const std::string &name, HardwareSerial &serial_port)
     : Device(name), _serial_port(serial_port) {}
+#else
+Piksi::Piksi(const std::string &name) {}
+    //: Device(name) {}
+//Piksi::Piksi();
+#endif
+
 
 bool Piksi::setup() {
+    #ifndef DESKTOP
     _serial_port.begin(BAUD_RATE);
+    #endif
 
     clear_log();
     _heartbeat.flags = 1;  // By default, let there be an error in the system.
@@ -74,73 +89,6 @@ bool Piksi::setup() {
     return (registration_successful == 0);
 }
 
-void Piksi::write_default_settings() {
-    // Output controls.
-    const char *gpgll_output_rate = "nmea\000gpgll msg rate\0000";
-    const char *gpgsv_output_rate = "nmea\000gpgsv msg rate\0000";
-    const char *gprmc_output_rate = "nmea\000gprmc msg rate\0000";
-    const char *gpvtg_output_rate = "nmea\000gpvtg msg rate\0000";
-    const char *obs_msg_max_size = "sbp\000obs msg max size\000102";  // This is a default specified
-                                                                      // by SwiftNav
-    const char *obs_output_rate = "solution\000output every n obs\0001";
-    const char *soln_frequency =
-        "solution\000soln freq\00010";  // This is a default specified by SwiftNav
-    const char *broadcast_surveyed_position = "surveyed position\000broadcast\000true";
-    // RTK solution settings.
-    const char *dgnss_solution_mode = "solution\000dgnss solution mode\000TimeMatched";
-    // Hardware watchdog.
-    const char *enable_hardware_watchdog = "system monitor\000watchdog\000true";
-    // Heartbeat output rate.
-    const char *heartbeat_period = "system monitor\000heartbeat period milliseconds\00010000";
-    // Telemetry radio settings
-    const char *telemetry_settings =
-        "telemetry radio\000configuration "
-        "string\000AT&F,ATS1=57,ATS2=64,ATS5=0,AT&W,"
-        "ATZ";
-
-    // UART A (radio) settings.
-    const char *uart_a_output_mask =
-        "uart uarta\000sbp message mask\0000x0840";  // MSG_OBS | MSG_USER_DATA
-    const char *uart_a_configure_radio_on_boot =
-        "uart uarta\000configure telemetry radio on boot\000true";
-    const char *uart_a_baudrate = "uart uarta\000baudrate\00057600";  // This is a default specified
-                                                                      // by SwiftNav
-
-    // UART B (controller) output mask.
-    const char *uart_b_output_mask =
-        "uart uarta\000sbp message mask\0000xffff";  // Every message is passed to
-                                                     // controller
-    const char *uart_b_configure_radio_on_boot =
-        "uart uarta\000configure telemetry radio on boot\000false";
-    const char *uart_b_baudrate = "uart uarta\000baudrate\000115200";  // This is a default
-                                                                       // specified by SwiftNav
-
-    // Now write the settings to the device!
-    const char *settings[] = {gpgll_output_rate,
-                              gpgsv_output_rate,
-                              gprmc_output_rate,
-                              gpvtg_output_rate,
-                              obs_msg_max_size,
-                              obs_output_rate,
-                              soln_frequency,
-                              broadcast_surveyed_position,
-                              dgnss_solution_mode,
-                              enable_hardware_watchdog,
-                              heartbeat_period,
-                              telemetry_settings,
-                              uart_a_output_mask,
-                              uart_a_configure_radio_on_boot,
-                              uart_a_baudrate,
-                              uart_b_output_mask,
-                              uart_b_configure_radio_on_boot,
-                              uart_b_baudrate};
-    for (unsigned char i = 0; i < sizeof(settings) / sizeof(std::string); i++) {
-        msg_settings_write_t setting;
-        memcpy(setting.setting, settings[i], sizeof(settings[i]) / sizeof(char));
-        settings_write(setting);
-    }
-}
-
 bool Piksi::is_functional() {
     return is_system_healthy() && is_system_io_healthy() && is_swiftnap_healthy() &&
            is_antenna_healthy();
@@ -152,8 +100,9 @@ void Piksi::disable() {
     // Do nothing; we really don't want to disable Piksi
 }
 
-void Piksi::get_gps_time(gps_time_t *time) {
-    *time = _gps_time;
+void Piksi::get_gps_time(msg_gps_time_t *time) {
+    time->wn = _gps_time.wn;
+    time->tow = _gps_time.tow;
 }
 
 unsigned int Piksi::get_dops_tow() { return _dops.tow; }
@@ -168,22 +117,47 @@ void Piksi::get_pos_ecef(std::array<double, 3> *position) {
     (*position)[1] = _pos_ecef.y;
     (*position)[2] = _pos_ecef.z;
 }
-unsigned char Piksi::get_pos_ecef_nsats() { return _pos_ecef.n_sats; }
-unsigned char Piksi::get_pos_ecef_flags() { return _pos_ecef.flags; }
 
-void Piksi::get_baseline_ecef(std::array<double, 3> *position) {
+void Piksi::get_pos_ecef(unsigned int *tow, std::array<double, 3> *position) {
+    (*tow) = _pos_ecef.tow;
     (*position)[0] = _pos_ecef.x;
     (*position)[1] = _pos_ecef.y;
     (*position)[2] = _pos_ecef.z;
 }
+
+unsigned char Piksi::get_pos_ecef_nsats() { return _pos_ecef.n_sats; }
+unsigned char Piksi::get_pos_ecef_flags() { return _pos_ecef.flags % 8; }
+
+void Piksi::get_baseline_ecef(std::array<double, 3> *position) {
+    (*position)[0] = _baseline_ecef.x;
+    (*position)[1] = _baseline_ecef.y;
+    (*position)[2] = _baseline_ecef.z;
+}
+
+void Piksi::get_baseline_ecef(unsigned int *tow, std::array<double, 3> *position) {
+    *tow = _baseline_ecef.tow;
+    (*position)[0] = _baseline_ecef.x;
+    (*position)[1] = _baseline_ecef.y;
+    (*position)[2] = _baseline_ecef.z;
+}
+
 unsigned char Piksi::get_baseline_ecef_nsats() { return _baseline_ecef.n_sats; }
 unsigned char Piksi::get_baseline_ecef_flags() { return _baseline_ecef.flags; }
 
 void Piksi::get_vel_ecef(std::array<double, 3> *velocity) {
-    (*velocity)[0] = _pos_ecef.x;
-    (*velocity)[1] = _pos_ecef.y;
-    (*velocity)[2] = _pos_ecef.z;
+    (*velocity)[0] = _vel_ecef.x;
+    (*velocity)[1] = _vel_ecef.y;
+    (*velocity)[2] = _vel_ecef.z;
 }
+
+void Piksi::get_vel_ecef(unsigned int *tow, std::array<double, 3> *velocity) {
+    *tow = _vel_ecef.tow;
+    (*velocity)[0] = _vel_ecef.x;
+    (*velocity)[1] = _vel_ecef.y;
+    (*velocity)[2] = _vel_ecef.z;
+    
+}
+
 unsigned char Piksi::get_vel_ecef_nsats() { return _vel_ecef.n_sats; }
 unsigned char Piksi::get_vel_ecef_flags() { return _vel_ecef.flags; }
 
@@ -192,6 +166,37 @@ void Piksi::get_base_pos_ecef(std::array<double, 3> *position) {
     (*position)[1] = _pos_ecef.y;
     (*position)[2] = _pos_ecef.z;
 }
+
+#ifdef DESKTOP
+void Piksi::set_gps_time(const unsigned int tow){
+    _gps_time.tow = tow;
+}
+void Piksi::set_pos_ecef(const unsigned int tow, const std::array<double,3>& position, const unsigned char nsats){
+    _pos_ecef.tow = tow;
+    _pos_ecef.x = position[0];
+    _pos_ecef.y = position[1];
+    _pos_ecef.z = position[2];
+    _pos_ecef.n_sats = nsats;
+}
+void Piksi::set_vel_ecef(const unsigned int tow, const std::array<double,3>& velocity){
+    _vel_ecef.tow = tow;
+    _vel_ecef.x = velocity[0];
+    _vel_ecef.y = velocity[1];
+    _vel_ecef.z = velocity[2];
+}
+void Piksi::set_baseline_ecef(const unsigned int tow, const std::array<double,3>& position){
+    _baseline_ecef.tow = tow;
+    _baseline_ecef.x = position[0];
+    _baseline_ecef.y = position[1];
+    _baseline_ecef.z = position[2];
+}
+void Piksi::set_baseline_flag(const unsigned char flag){
+    _baseline_ecef.flags = flag;
+}
+void Piksi::set_read_return(const unsigned int out){
+    _read_return = out;
+}
+#endif
 
 unsigned int Piksi::get_iar() { return _iar.num_hyps; }
 
@@ -247,10 +252,81 @@ void Piksi::send_user_data(const msg_user_data_t &data) {
                      (unsigned char *)&data, &Piksi::_uart_write);
 }
 
-bool Piksi::process_buffer() { return sbp_process(&_sbp_state, Piksi::_uart_read) > 0; }
+signed char Piksi::process_buffer() {
+    signed char status = ((signed char)sbp_process(&_sbp_state, Piksi::_uart_read));
+    return status;
+}
+
+unsigned char Piksi::process_buffer_msg_len() {
+    unsigned char pre = _sbp_state.msg_len;
+    signed char status = ((signed char)sbp_process(&_sbp_state, Piksi::_uart_read));
+
+    if (status == SBP_OK_CALLBACK_EXECUTED || status == SBP_OK_CALLBACK_UNDEFINED)
+        return pre;
+
+    return 0;
+}
+
+unsigned char Piksi::read_all() {
+    #ifdef DESKTOP
+    return _read_return;
+    #else
+    
+    _gps_time_update = false;
+    _pos_ecef_update = false;
+    _vel_ecef_update = false;
+    _baseline_ecef_update = false;
+
+    int initial_time = micros();
+    
+    if(bytes_available()){
+        bool crc_error = false;
+        while(bytes_available() && (micros() - initial_time < 900)){
+            int p_b_return = process_buffer();
+            if(p_b_return < 0)
+                crc_error = true;
+        }
+        if(micros()-initial_time >= 900){
+            clear_bytes();
+            return 5;
+        }
+  
+        if(_gps_time_update && _pos_ecef_update && _vel_ecef_update && !_baseline_ecef_update)
+            return 0;
+        else if(_gps_time_update && _pos_ecef_update && _vel_ecef_update && _baseline_ecef_update)
+            return 1;
+        else if(crc_error)
+            return 3;
+        else
+            //error condition, perhaps serial data bad
+            //or time looped around
+            return 2;
+    }
+    else
+        //no bytes return condition
+        return 4;
+    #endif
+}
+
+u32 Piksi::bytes_available() { 
+    #ifndef DESKTOP
+    return _serial_port.available(); 
+    #else
+
+    #endif
+    return 0;
+}
+
+void Piksi::clear_bytes() { 
+    #ifndef DESKTOP
+    _serial_port.clear(); 
+    #endif
+    }
 
 u32 Piksi::_uart_read(u8 *buff, u32 n, void *context) {
+    #ifndef DESKTOP
     Piksi *piksi = (Piksi *)context;
+    
     HardwareSerial &sp = piksi->_serial_port;
 
     u32 i;
@@ -261,9 +337,14 @@ u32 Piksi::_uart_read(u8 *buff, u32 n, void *context) {
             break;
     }
     return i;
+    #else
+    return 0;
+    #endif
 }
 
 u32 Piksi::_uart_write(u8 *buff, u32 n, void *context) {
+    #ifndef DESKTOP
+
     Piksi *piksi = (Piksi *)context;
     HardwareSerial &sp = piksi->_serial_port;
     u32 i;
@@ -271,6 +352,9 @@ u32 Piksi::_uart_write(u8 *buff, u32 n, void *context) {
         if (sp.write(buff[i]) == 0) break;
     }
     return i;
+    #else
+    return 0;
+    #endif
 }
 
 void Piksi::_insert_log_msg(u8 msg[]) {
@@ -296,22 +380,28 @@ void Piksi::_log_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
 void Piksi::_gps_time_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
     Piksi *piksi = (Piksi *)context;
     memcpy((u8 *)(&(piksi->_gps_time)), msg, sizeof(msg_gps_time_t));
+    piksi->_gps_time_update = true;
 }
+
 void Piksi::_dops_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
     Piksi *piksi = (Piksi *)context;
     memcpy((u8 *)(&(piksi->_dops)), msg, sizeof(msg_dops_t));
 }
+
 void Piksi::_pos_ecef_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
     Piksi *piksi = (Piksi *)context;
     memcpy((u8 *)(&(piksi->_pos_ecef)), msg, sizeof(msg_pos_ecef_t));
+    piksi->_pos_ecef_update = true;
 }
 void Piksi::_baseline_ecef_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
     Piksi *piksi = (Piksi *)context;
     memcpy((u8 *)(&(piksi->_baseline_ecef)), msg, sizeof(msg_baseline_ecef_t));
+    piksi->_baseline_ecef_update = true;
 }
 void Piksi::_vel_ecef_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
     Piksi *piksi = (Piksi *)context;
     memcpy((u8 *)(&(piksi->_vel_ecef)), msg, sizeof(msg_vel_ecef_t));
+    piksi->_vel_ecef_update = true;
 }
 void Piksi::_base_pos_ecef_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
     Piksi *piksi = (Piksi *)context;
@@ -328,6 +418,7 @@ void Piksi::_settings_read_resp_callback(u16 sender_id, u8 len, u8 msg[], void *
 void Piksi::_heartbeat_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
     Piksi *piksi = (Piksi *)context;
     memcpy((u8 *)(&(piksi->_heartbeat)), msg, sizeof(msg_heartbeat_t));
+    piksi->_heartbeat_update = true;
 }
 void Piksi::_startup_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
     Piksi *piksi = (Piksi *)context;
@@ -340,5 +431,5 @@ void Piksi::_uart_state_callback(u16 sender_id, u8 len, u8 msg[], void *context)
 void Piksi::_user_data_callback(u16 sender_id, u8 len, u8 msg[], void *context) {
     Piksi *piksi = (Piksi *)context;
     memcpy((u8 *)(&(piksi->_user_data)), msg, sizeof(msg_user_data_t));
+    piksi->_user_data_update = true;
 }
-#endif

--- a/lib/Drivers/Piksi.hpp
+++ b/lib/Drivers/Piksi.hpp
@@ -31,6 +31,8 @@ class Piksi {
    public:
     //! Baud rate of communication with Piksi.
     static constexpr unsigned int BAUD_RATE = 115200;
+    // Driver limit for max processing time of read_all()
+    static constexpr unsigned int READ_ALL_LIMIT = 900;
 
     /**
      * @brief Construct a new Piksi object

--- a/lib/Drivers/Piksi.hpp
+++ b/lib/Drivers/Piksi.hpp
@@ -1,11 +1,16 @@
 #ifndef PIKSI_HPP_
 #define PIKSI_HPP_
-#ifndef DESKTOP
 
+#ifndef DESKTOP
 #include <HardwareSerial.h>
+#include "../Devices/Device.hpp"
+#else
+#include <iostream>
+#include <string>
+#endif
+
 #include <GPSTime.hpp>
 #include <array>
-#include "../Devices/Device.hpp"
 #include "../libsbp/logging.h"
 #include "../libsbp/navigation.h"
 #include "../libsbp/observation.h"
@@ -18,7 +23,11 @@ namespace Devices {
 /**
  * @brief Device class for interacting with the Piksi GPS system.
  */
+#ifndef DESKTOP
 class Piksi : public Device {
+#else
+class Piksi {
+#endif
    public:
     //! Baud rate of communication with Piksi.
     static constexpr unsigned int BAUD_RATE = 115200;
@@ -28,85 +37,191 @@ class Piksi : public Device {
      *
      * @param serial_port The serial port that the Piksi communicates over.
      */
+    #ifndef DESKTOP
     Piksi(const std::string &name, HardwareSerial &serial_port);
+    #else
+    using String = std::string;
+    //Piksi();
+    Piksi(const std::string &name);
+    #endif
 
     // Standard device functions
+    #ifndef DESKTOP
     bool setup() override;
     bool is_functional() override;
     void reset() override;
     void disable() override;  // Sets Piksi's power consumption to a minimum
+    #else
+    bool setup();
+    bool is_functional();
+    void reset();
+    void disable();  // Sets Piksi's power consumption to a minimum
+    #endif
+
+    
 
     /** @brief Runs read over UART buffer to process values sent by Piksi into
      * memory.
      *  @returns Whether or not any data was processed. **/
-    virtual bool process_buffer();
+    virtual signed char process_buffer();
+
+    /**
+     * @brief Runs read over UART buffer to process values sent by Piksi using libsbp
+     * 
+     * TODO DETERMINE IF Piksi is sending baseline packets when SPP
+     * Could be not sending or sending a baseline packet with no data/0's
+     * 
+     * Let it be known that the Piksi doesn't have save previous information
+     * Ex switching into Piksi
+     *
+     * @return Returns the number of bytes processed by a call of process_buffer_msg_len()
+     * These values coincide with the message size in the piksi documentation
+     * Note that message size is not the same number of bytes
+     * that is sent for that message (unfortunately)
+     */
+    virtual unsigned char process_buffer_msg_len();
+
+    /**
+     * @brief While bytes are in the buffer, process them.
+     *
+     * This method will process bytes in the buffer and set internal fields
+     * in the driver to be harvested by a control task by calling getters.
+     * 
+     * Experimentally this always finished in 650 +- 50 microseconds
+     * 
+     * 
+     * @return return code
+     * 0 if only time, pos and vel were updated, indicative of SPP
+     * 1 if time, pos, vel and baseline were updated indicative of something_RTK
+     * 2 if time, pos and vel were not updated, indicative of NO_FIX
+     * 3 if time, pos and vel were not updated, and a crc error happened
+     * 4 if there are no bytes in the buffer
+     * 5 if the process_buffer loop is unable to deal with all the bytes in 900 microseconds
+     */
+    virtual unsigned char read_all();
 
     /** @brief Gets GPS time.
-     *  @return GPS time, as nanoseconds since the epoch. **/
-    virtual void get_gps_time(gps_time_t *time);
+     *  @return msg_gps_time_t, a struct of time since epoch **/
+    virtual void get_gps_time(msg_gps_time_t *time);
 
     /** @brief Gets Dilution of Precision timestamp.
      *  @return Time-of-week of dilution precision report, in milliseconds. **/
     unsigned int get_dops_tow();
+
     /** @brief Gets Geometric Dilution of Precision.
      *  @return Geometric dilution of precision. **/
     unsigned short int get_dops_geometric();
+
     /** @brief Gets Position Dilution of Precision.
      *  @return Position dilution of precision. **/
     unsigned short int get_dops_position();
+
     /** @brief Gets Time Dilution of Precision.
      *  @return Time dilution of precision. **/
     unsigned short int get_dops_time();
+
     /** @brief Gets Horizontal Dilution of Precision.
      *  @return Horizontal dilution of precision. **/
     unsigned short int get_dops_horizontal();
+
     /** @brief Gets Vertical Dilution of Precision.
      *  @return Vertical dilution of precision. **/
     unsigned short int get_dops_vertical();
 
-    /** @brief Gets satellite position in ECEF coordinates.
-     *  @param position A pointer to the destination struct for the information.
-     * **/
+    /**
+     * @brief Get the position in ECEF coordinates
+     * 
+     * @param position A pointer to an std::array of doubles for the position
+     */
     virtual void get_pos_ecef(std::array<double, 3> *position);
+
+    /**
+     * @brief Get the Position in ECEF coordinates, and the time of week int
+     *
+     * @param tow A pointer to the tow int
+     * @param position A pointer to the std::array of doubles for the position
+     */
+    virtual void get_pos_ecef(unsigned int *tow, std::array<double, 3> *position);
+
     /** @brief Get number of satellites used for determining GPS position.
      *  @return Number of satellites used for determining GPS position. **/
     virtual unsigned char get_pos_ecef_nsats();
+
     /** @brief Get status flags of GPS position measurement.
+     * returns 0 if SPP
+     * returns 1 if FIXED RTK
+     * returns 2 if FLOAT RTK
+     * 
+     * modded by 8 to prevent spirulus values
      *  @return Status flags of GPS position measurement. **/
     virtual unsigned char get_pos_ecef_flags();
 
-    /** @brief Gets satellite position in ECEF coordinates relative to base
-     * station.
-     *  @param position A pointer to the destination struct for the information.
-     * **/
+    /**
+     * @brief Get the baseline ECEF coordinates
+     * 
+     * @param position A pointer to the std::array of doubles for the baseline position
+     */
     virtual void get_baseline_ecef(std::array<double, 3> *position);
+
+    /**
+     * @brief Get the baseline ECEF coordinates, and the time of week int
+     *
+     * @param tow A pointer to the tow int
+     * @param position A pointer to the std::array of doubles for the baseline position
+     */
+    virtual void get_baseline_ecef(unsigned int *tow, std::array<double, 3> *position);
+
     /** @brief Get number of satellites used for determining GPS baseline
      * position.
      *  @return Number of satellites used for determining GPS baseline position.
      * **/
     virtual unsigned char get_baseline_ecef_nsats();
+
     /** @brief Get status flags of GPS baseline position measurement.
+     * returns 1 if fixed RTK
+     * returns 0 if float RTK
+     * returns 0 if SPP
      *  @return Status flags of GPS baseline position measurement. **/
     unsigned char get_baseline_ecef_flags();
 
     /** @brief Gets satellite velocity in ECEF coordinates.
-     *  @param velocity A pointer to the destination struct for the information.
+     *  @param velocity A pointer to the std::array of doubles for velocity
      * **/
     virtual void get_vel_ecef(std::array<double, 3> *velocity);
+
+    /**
+     * @brief Gets satellite velocity in ECEF coordinates and the time of week.
+     *
+     * @param int A pointer to the tow int
+     * @param velocity A pointer to the std::array of doubles for velocity
+     */
+    virtual void get_vel_ecef(unsigned int *tow, std::array<double, 3> *velocity);
+
     /** @brief Get number of satellites used for determining GPS velocity.
      *  @return Number of satellites used for determining GPS velocity. **/
     virtual unsigned char get_vel_ecef_nsats();
+
     /** @brief Get status flags of GPS velocity measurement.
      *  @return Status flags of GPS velocity measurement. **/
     unsigned char get_vel_ecef_flags();
 
     /** @brief Gets base station position in ECEF coordinates.
-     *  @param position A pointer to an array for storing the x,y,z coordinates of
+     *  @param position A pointer to an std::array of doubles for storing the x,y,z coordinates of
      * the base station. **/
     virtual void get_base_pos_ecef(std::array<double, 3> *position);
 
     /** @brief Returns state of integer ambiguity resolution (IAR) process. **/
     virtual unsigned int get_iar();
+
+    //set of mocking methods
+    #ifdef DESKTOP
+    void set_gps_time(const unsigned int tow);
+    void set_pos_ecef(const unsigned int tow, const std::array<double, 3>& position, const unsigned char nsats);
+    void set_vel_ecef(const unsigned int tow, const std::array<double, 3>& velocity);
+    void set_baseline_ecef(const unsigned int tow, const std::array<double, 3>& position);
+    void set_baseline_flag(const unsigned char flag);
+    void set_read_return(const unsigned int out);
+    #endif
 
     /** @brief Reads current settings in Piksi RAM.
      *  @return Current settings in Piksi RAM, as a libsbp struct. **/
@@ -115,15 +230,19 @@ class Piksi : public Device {
     /** @brief Reads status flags of Piksi (i.e. the "heartbeat").
      *  @return Status flags of Piksi, as a libsbp struct. **/
     unsigned int get_heartbeat();
+
     /** @brief Reads "system health" bit of status flags of Piksi.
      *  @return Whether or not the system is healthy. **/
     bool is_system_healthy();
+
     /** @brief Reads "system I/O health" bit of status flags of Piksi.
      *  @return Whether or not the system I/O is healthy. **/
     bool is_system_io_healthy();
+
     /** @brief Reads "SwiftNAP health" bit of status flags of Piksi.
      *  @return Whether or not the SwiftNAP system is healthy. **/
     bool is_swiftnap_healthy();
+
     /** @brief Reads "antenna health" bit of status flags of Piksi.
      *  @return Whether or not the antenna is healthy. **/
     bool is_antenna_healthy();
@@ -131,18 +250,23 @@ class Piksi : public Device {
     /** @brief Reads UART channel A transmission throughput.
      *  @return UART A channel transmission throughput. **/
     float get_uart_a_tx_throughput();
+
     /** @brief Reads UART channel A reception throughput.
      *  @return UART A channel reception throughput. **/
     float get_uart_a_rx_throughput();
+
     /** @brief Reads UART channel A CRC error count.
      *  @return UART A channel CRC error count. **/
     unsigned short int get_uart_a_crc_error_count();
+
     /** @brief Reads UART channel A I/O error count.
      *  @return UART A channel I/O error count. **/
     unsigned short int get_uart_a_io_error_count();
+
     /** @brief Reads UART channel A transmission buffer utilization.
      *  @return UART A channel transmission buffer utilization. **/
     unsigned char get_uart_a_tx_buffer_utilization();
+
     /** @brief Reads UART channel A reception buffer utilization.
      *  @return UART A channel reception buffer utilization. **/
     unsigned char get_uart_a_rx_buffer_utilization();
@@ -150,18 +274,23 @@ class Piksi : public Device {
     /** @brief Reads UART channel B transmission throughput.
      *  @return UART B channel transmission throughput. **/
     float get_uart_b_tx_throughput();
+
     /** @brief Reads UART channel B reception throughput.
      *  @return UART B channel reception throughput. **/
     float get_uart_b_rx_throughput();
+
     /** @brief Reads UART channel B CRC error count.
      *  @return UART B channel CRC error count. **/
     unsigned short int get_uart_b_crc_error_count();
+
     /** @brief Reads UART channel B I/O error count.
      *  @return UART B channel I/O error count. **/
     unsigned short int get_uart_b_io_error_count();
+
     /** @brief Reads UART channel B transmission buffer utilization.
      *  @return UART B channel transmission buffer utilization. **/
     unsigned char get_uart_b_tx_buffer_utilization();
+
     /** @brief Reads UART channel B reception buffer utilization.
      *  @return UART B channel reception buffer utilization. **/
     unsigned char get_uart_b_rx_buffer_utilization();
@@ -172,12 +301,10 @@ class Piksi : public Device {
 
     /** @brief Saves the data settings to flash. **/
     void settings_save();
+
     /** @brief Writes the desired settings to the Piksi's RAM.
      * @param settings Struct containing setting changes for the Piksi. **/
     void settings_write(const msg_settings_write_t &settings);
-    /** @brief Creates settings object containing default settings for PAN and
-     * writes them to RAM. **/
-    void write_default_settings();
 
     /** @brief Resets Piksi. **/
     void piksi_reset();
@@ -194,9 +321,24 @@ class Piksi : public Device {
     /** @brief Clear out logbook. */
     void clear_log();
 
+    /**
+     * @brief Returns the number of bytes available on the serial port to read
+     *
+     * @return u32 number of bytes available
+     */
+    u32 bytes_available();
+
+    /**
+     * @brief Clears all the bytes waiting to be read on the serial port
+     *
+     */
+    void clear_bytes();
+
    protected:
+   #ifndef DESKTOP
     HardwareSerial &_serial_port;  // This is protected instead of private so that FakePiksi
                                    // can access the port variable
+    #endif
    private:
     // Internal values required by libsbp. See sbp.c
     sbp_state_t _sbp_state;
@@ -257,8 +399,21 @@ class Piksi : public Device {
     msg_heartbeat_t _heartbeat;
     msg_uart_state_t _uart_state;
     msg_user_data_t _user_data;
-};
-}  // namespace Devices
 
-#endif
+    //set of fields to see if callbacks have been called
+    bool _gps_time_update;
+    bool _pos_ecef_update;
+    bool _baseline_ecef_update;
+    bool _vel_ecef_update;
+    bool _iar_update;
+    bool _heartbeat_update;
+    bool _user_data_update;
+
+    //set read return mock
+    #ifdef DESKTOP
+    unsigned int _read_return;
+    #endif
+};
+}
+
 #endif

--- a/src/FCCode/PiksiControlTask.cpp
+++ b/src/FCCode/PiksiControlTask.cpp
@@ -1,29 +1,28 @@
 #include "PiksiControlTask.hpp"
-#include "piksi_mode_t.enum"
 
-using namespace Devices;
+PiksiControlTask::PiksiControlTask(StateFieldRegistry &registry, 
+    unsigned int offset, Devices::Piksi &_piksi) 
+    : TimedControlTask<void>(registry, offset),
+    piksi(_piksi),
+    pos_sr(0, 100000, 100),
+    pos_f("piksi.pos", pos_sr),
+    vel_sr(0, 100000, 100),
+    vel_f("piksi.vel", vel_sr),
+    baseline_pos_sr(0, 100000, 100),
+    baseline_pos_f("piksi.baseline_pos", baseline_pos_sr),
+    current_state_sr(0, 4, 2),
+    current_state_f("piksi.state", current_state_sr),
+    time_sr(),
+    time_f("piksi.time", time_sr)
+    {
+        add_readable_field(pos_f);
+        add_readable_field(vel_f);
+        add_readable_field(baseline_pos_f);
+        add_readable_field(current_state_f);
+        add_readable_field(time_f);
 
-PiksiControlTask::PiksiControlTask(StateFieldRegistry &registry, unsigned int offset, Devices::Piksi &_piksi) : TimedControlTask<void>(registry, offset),
-                                                                   piksi(_piksi),
-                                                                   pos_sr(0, 100000, 100),
-                                                                   pos_f("piksi.pos", pos_sr),
-                                                                   vel_sr(0, 100000, 100),
-                                                                   vel_f("piksi.vel", vel_sr),
-                                                                   baseline_pos_sr(0, 100000, 100),
-                                                                   baseline_pos_f("piksi.baseline_pos", baseline_pos_sr),
-                                                                   currentState_sr(0, 4, 2),
-                                                                   currentState_f("piksi.state", currentState_sr),
-                                                                   time_sr(),
-                                                                   time_f("piksi.time", time_sr)
-{
-    add_readable_field(pos_f);
-    add_readable_field(vel_f);
-    add_readable_field(baseline_pos_f);
-    add_readable_field(currentState_f);
-    add_readable_field(time_f);
-
-    currentState_f.set(static_cast<int>(piksi_mode_t::no_fix));
-}
+        current_state_f.set(static_cast<unsigned int>(piksi_mode_t::no_fix));
+    }
 
 void PiksiControlTask::execute()
 {  
@@ -40,29 +39,29 @@ void PiksiControlTask::execute()
     //if we haven't had a good reading in ~120 seconds the piksi is probably dead
     //eventually replace with HAVT logic
     if(since_good_cycles > 1000){
-        currentState_f.set(static_cast<int>(piksi_mode_t::dead));
+        current_state_f.set(static_cast<unsigned int>(piksi_mode_t::dead));
         //prevent roll over
         since_good_cycles = 1001;
         return;
     }
 
     if(read_out == 5){
-        currentState_f.set(static_cast<int>(piksi_mode_t::time_limit_error));
+        current_state_f.set(static_cast<unsigned int>(piksi_mode_t::time_limit_error));
         return;
     }
 
     else if(read_out == 4){
-        currentState_f.set(static_cast<int>(piksi_mode_t::no_data_error));
+        current_state_f.set(static_cast<unsigned int>(piksi_mode_t::no_data_error));
         return;
     }
 
     else if(read_out == 3){
-        currentState_f.set(static_cast<int>(piksi_mode_t::crc_error));
+        current_state_f.set(static_cast<unsigned int>(piksi_mode_t::crc_error));
         return;
     }
 
     else if(read_out == 2){
-        currentState_f.set(static_cast<int>(piksi_mode_t::no_fix));
+        current_state_f.set(static_cast<unsigned int>(piksi_mode_t::no_fix));
         return;
     }
 
@@ -87,30 +86,30 @@ void PiksiControlTask::execute()
             //error caused by times not matching up
             //indicitave of getting only part of the next scream
 
-            currentState_f.set(static_cast<int>(piksi_mode_t::sync_error));
+            current_state_f.set(static_cast<unsigned int>(piksi_mode_t::sync_error));
             return;
         }
 
         int nsats = piksi.get_pos_ecef_nsats();
         if(nsats < 4){
-            currentState_f.set(static_cast<int>(piksi_mode_t::nsat_error));
+            current_state_f.set(static_cast<unsigned int>(piksi_mode_t::nsat_error));
             return;
         }
 
         if(read_out == 0) {
-            currentState_f.set(static_cast<int>(piksi_mode_t::spp));
+            current_state_f.set(static_cast<unsigned int>(piksi_mode_t::spp));
         }
         if(read_out == 1){
             int baseline_flag = piksi.get_baseline_ecef_flags();
             if(baseline_flag == 1){
-                currentState_f.set(static_cast<int>(piksi_mode_t::fixed_rtk));
+                current_state_f.set(static_cast<unsigned int>(piksi_mode_t::fixed_rtk));
             }
             else if(baseline_flag == 0){
-                currentState_f.set(static_cast<int>(piksi_mode_t::float_rtk));
+                current_state_f.set(static_cast<unsigned int>(piksi_mode_t::float_rtk));
             }
             else{
                 //baseline flag unexpected value
-                currentState_f.set(static_cast<int>(piksi_mode_t::data_error));
+                current_state_f.set(static_cast<unsigned int>(piksi_mode_t::data_error));
                 return;
             }
         }
@@ -127,7 +126,7 @@ void PiksiControlTask::execute()
 
     //if read_out is unexpected value which it shouldn't do lol
     else{
-        currentState_f.set(static_cast<int>(piksi_mode_t::data_error));
+        current_state_f.set(static_cast<unsigned int>(piksi_mode_t::data_error));
         return;
     }
 

--- a/src/FCCode/PiksiControlTask.cpp
+++ b/src/FCCode/PiksiControlTask.cpp
@@ -38,7 +38,7 @@ void PiksiControlTask::execute()
         
     //if we haven't had a good reading in ~120 seconds the piksi is probably dead
     //eventually replace with HAVT logic
-    if(since_good_cycles > 1000){
+    if(since_good_cycles > DEAD_CYCLE_COUNT){
         current_state_f.set(static_cast<unsigned int>(piksi_mode_t::dead));
         //prevent roll over
         since_good_cycles = 1001;

--- a/src/FCCode/PiksiControlTask.cpp
+++ b/src/FCCode/PiksiControlTask.cpp
@@ -1,0 +1,134 @@
+#include "PiksiControlTask.hpp"
+#include "piksi_mode_t.enum"
+
+using namespace Devices;
+
+PiksiControlTask::PiksiControlTask(StateFieldRegistry &registry, unsigned int offset, Devices::Piksi &_piksi) : TimedControlTask<void>(registry, offset),
+                                                                   piksi(_piksi),
+                                                                   pos_sr(0, 100000, 100),
+                                                                   pos_f("piksi.pos", pos_sr),
+                                                                   vel_sr(0, 100000, 100),
+                                                                   vel_f("piksi.vel", vel_sr),
+                                                                   baseline_pos_sr(0, 100000, 100),
+                                                                   baseline_pos_f("piksi.baseline_pos", baseline_pos_sr),
+                                                                   currentState_sr(0, 4, 2),
+                                                                   currentState_f("piksi.state", currentState_sr),
+                                                                   time_sr(),
+                                                                   time_f("piksi.time", time_sr)
+{
+    add_readable_field(pos_f);
+    add_readable_field(vel_f);
+    add_readable_field(baseline_pos_f);
+    add_readable_field(currentState_f);
+    add_readable_field(time_f);
+
+    currentState_f.set(static_cast<int>(piksi_mode_t::NO_FIX));
+}
+
+void PiksiControlTask::execute()
+{  
+    int read_out = piksi.read_all();
+
+    //4 means no bytes
+    //3 means CRC error on serial
+    //5 means timing error exceed
+    if(read_out == 3|| read_out == 4|| read_out == 5)
+        since_good_cycles += 1;
+    else 
+        since_good_cycles = 0;
+        
+    //if we haven't had a good reading in ~120 seconds the piksi is probably dead
+    //eventually replace with HAVT logic
+    if(since_good_cycles > 1000){
+        currentState_f.set(static_cast<int>(piksi_mode_t::DEAD));
+        //prevent roll over
+        since_good_cycles = 1001;
+        return;
+    }
+
+    if(read_out == 5){
+        currentState_f.set(static_cast<int>(piksi_mode_t::TIME_LIMIT_ERROR));
+        return;
+    }
+
+    else if(read_out == 4){
+        currentState_f.set(static_cast<int>(piksi_mode_t::NO_DATA_ERROR));
+        return;
+    }
+
+    else if(read_out == 3){
+        currentState_f.set(static_cast<int>(piksi_mode_t::CRC_ERROR));
+        return;
+    }
+
+    else if(read_out == 2){
+        currentState_f.set(static_cast<int>(piksi_mode_t::NO_FIX));
+        return;
+    }
+
+    else if(read_out == 1 || read_out == 0){
+        //get time from driver, then dump into a gps_time_t
+        piksi.get_gps_time(&msg_time);
+        time = gps_time_t(msg_time);
+
+        piksi.get_pos_ecef(&pos_tow, &pos);
+        piksi.get_vel_ecef(&vel_tow, &vel);
+
+        if(read_out == 1)
+            piksi.get_baseline_ecef(&baseline_tow, &baseline_pos);
+
+        bool check_time;
+        if(read_out == 1)
+            check_time = time.tow == pos_tow && time.tow == vel_tow && time.tow == baseline_tow;
+        else
+            check_time = time.tow == pos_tow && time.tow == vel_tow;
+
+        if(!check_time){
+            //error caused by times not matching up
+            //indicitave of getting only part of the next scream
+
+            currentState_f.set(static_cast<int>(piksi_mode_t::SYNC_ERROR));
+            return;
+        }
+
+        int nsats = piksi.get_pos_ecef_nsats();
+        if(nsats < 4){
+            currentState_f.set(static_cast<int>(piksi_mode_t::NSAT_ERROR));
+            return;
+        }
+
+        if(read_out == 0) {
+            currentState_f.set(static_cast<int>(piksi_mode_t::SPP));
+        }
+        if(read_out == 1){
+            int baseline_flag = piksi.get_baseline_ecef_flags();
+            if(baseline_flag == 1){
+                currentState_f.set(static_cast<int>(piksi_mode_t::FIXED_RTK));
+            }
+            else if(baseline_flag == 0){
+                currentState_f.set(static_cast<int>(piksi_mode_t::FLOAT_RTK));
+            }
+            else{
+                //baseline flag unexpected value
+                currentState_f.set(static_cast<int>(piksi_mode_t::DATA_ERROR));
+                return;
+            }
+        }
+
+        //set values in data statefields
+        time_f.set(time);
+        pos_f.set(pos);
+        vel_f.set(vel);
+        if(read_out == 1){
+            baseline_pos_f.set(baseline_pos);
+        }
+
+    }
+
+    //if read_out is unexpected value which it shouldn't do lol
+    else{
+        currentState_f.set(static_cast<int>(piksi_mode_t::DATA_ERROR));
+        return;
+    }
+
+}

--- a/src/FCCode/PiksiControlTask.cpp
+++ b/src/FCCode/PiksiControlTask.cpp
@@ -22,7 +22,7 @@ PiksiControlTask::PiksiControlTask(StateFieldRegistry &registry, unsigned int of
     add_readable_field(currentState_f);
     add_readable_field(time_f);
 
-    currentState_f.set(static_cast<int>(piksi_mode_t::NO_FIX));
+    currentState_f.set(static_cast<int>(piksi_mode_t::no_fix));
 }
 
 void PiksiControlTask::execute()
@@ -40,29 +40,29 @@ void PiksiControlTask::execute()
     //if we haven't had a good reading in ~120 seconds the piksi is probably dead
     //eventually replace with HAVT logic
     if(since_good_cycles > 1000){
-        currentState_f.set(static_cast<int>(piksi_mode_t::DEAD));
+        currentState_f.set(static_cast<int>(piksi_mode_t::dead));
         //prevent roll over
         since_good_cycles = 1001;
         return;
     }
 
     if(read_out == 5){
-        currentState_f.set(static_cast<int>(piksi_mode_t::TIME_LIMIT_ERROR));
+        currentState_f.set(static_cast<int>(piksi_mode_t::time_limit_error));
         return;
     }
 
     else if(read_out == 4){
-        currentState_f.set(static_cast<int>(piksi_mode_t::NO_DATA_ERROR));
+        currentState_f.set(static_cast<int>(piksi_mode_t::no_data_error));
         return;
     }
 
     else if(read_out == 3){
-        currentState_f.set(static_cast<int>(piksi_mode_t::CRC_ERROR));
+        currentState_f.set(static_cast<int>(piksi_mode_t::crc_error));
         return;
     }
 
     else if(read_out == 2){
-        currentState_f.set(static_cast<int>(piksi_mode_t::NO_FIX));
+        currentState_f.set(static_cast<int>(piksi_mode_t::no_fix));
         return;
     }
 
@@ -87,30 +87,30 @@ void PiksiControlTask::execute()
             //error caused by times not matching up
             //indicitave of getting only part of the next scream
 
-            currentState_f.set(static_cast<int>(piksi_mode_t::SYNC_ERROR));
+            currentState_f.set(static_cast<int>(piksi_mode_t::sync_error));
             return;
         }
 
         int nsats = piksi.get_pos_ecef_nsats();
         if(nsats < 4){
-            currentState_f.set(static_cast<int>(piksi_mode_t::NSAT_ERROR));
+            currentState_f.set(static_cast<int>(piksi_mode_t::nsat_error));
             return;
         }
 
         if(read_out == 0) {
-            currentState_f.set(static_cast<int>(piksi_mode_t::SPP));
+            currentState_f.set(static_cast<int>(piksi_mode_t::spp));
         }
         if(read_out == 1){
             int baseline_flag = piksi.get_baseline_ecef_flags();
             if(baseline_flag == 1){
-                currentState_f.set(static_cast<int>(piksi_mode_t::FIXED_RTK));
+                currentState_f.set(static_cast<int>(piksi_mode_t::fixed_rtk));
             }
             else if(baseline_flag == 0){
-                currentState_f.set(static_cast<int>(piksi_mode_t::FLOAT_RTK));
+                currentState_f.set(static_cast<int>(piksi_mode_t::float_rtk));
             }
             else{
                 //baseline flag unexpected value
-                currentState_f.set(static_cast<int>(piksi_mode_t::DATA_ERROR));
+                currentState_f.set(static_cast<int>(piksi_mode_t::data_error));
                 return;
             }
         }
@@ -127,7 +127,7 @@ void PiksiControlTask::execute()
 
     //if read_out is unexpected value which it shouldn't do lol
     else{
-        currentState_f.set(static_cast<int>(piksi_mode_t::DATA_ERROR));
+        currentState_f.set(static_cast<int>(piksi_mode_t::data_error));
         return;
     }
 

--- a/src/FCCode/PiksiControlTask.hpp
+++ b/src/FCCode/PiksiControlTask.hpp
@@ -11,6 +11,8 @@
 class PiksiControlTask : public TimedControlTask<void>
 {
 public:
+    static constexpr unsigned int DEAD_CYCLE_COUNT = 1000;
+
     PiksiControlTask(StateFieldRegistry &registry, unsigned int offset, Devices::Piksi &_piksi);
     
     Devices::Piksi& piksi;

--- a/src/FCCode/PiksiControlTask.hpp
+++ b/src/FCCode/PiksiControlTask.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <ControlTask.hpp>
+#include <Piksi.hpp>
+#include <string>
+#include <GPSTime.hpp>
+
+#include <TimedControlTask.hpp>
+
+#include "piksi_mode_t.enum"
+
+class PiksiControlTask : public TimedControlTask<void>
+{
+public:
+    PiksiControlTask(StateFieldRegistry &registry, unsigned int offset, Devices::Piksi &_piksi);
+    
+    Devices::Piksi& piksi;
+    /** 
+    * execute is overriden from TimedControlTask 
+    */
+    void execute() override;
+
+    //Serializer and StateField for position
+    Serializer<d_vector_t> pos_sr;
+    ReadableStateField<d_vector_t> pos_f;
+
+    //Serializer and StateField for velocity
+    Serializer<d_vector_t> vel_sr;
+    ReadableStateField<d_vector_t> vel_f;
+
+    //Serializer and StateField for baseline
+    Serializer<d_vector_t> baseline_pos_sr;
+    ReadableStateField<d_vector_t> baseline_pos_f;
+
+    //Serializer and StateField for currentState
+    Serializer<int> currentState_sr;
+    ReadableStateField<int> currentState_f;
+
+    //Serializer and StateField for time
+    Serializer<gps_time_t> time_sr;
+    ReadableStateField<gps_time_t> time_f;
+
+protected:
+    //Internal Data Containers
+    std::array<double, 3> pos;
+    std::array<double, 3> vel;
+    std::array<double, 3> baseline_pos;
+
+    msg_gps_time_t msg_time;
+    gps_time_t time;
+
+    unsigned int iar;
+
+    unsigned int pos_tow;
+
+    unsigned int vel_tow;
+
+    unsigned int baseline_tow;
+
+private:
+    // the number of cycles since a successful / meaningful read operation
+    unsigned int since_good_cycles = 0;
+
+};

--- a/src/FCCode/PiksiControlTask.hpp
+++ b/src/FCCode/PiksiControlTask.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ControlTask.hpp>
 #include <Piksi.hpp>
 #include <string>
 #include <GPSTime.hpp>
@@ -33,8 +32,8 @@ public:
     ReadableStateField<d_vector_t> baseline_pos_f;
 
     //Serializer and StateField for currentState
-    Serializer<int> currentState_sr;
-    ReadableStateField<int> currentState_f;
+    Serializer<unsigned int> current_state_sr;
+    ReadableStateField<unsigned int> current_state_f;
 
     //Serializer and StateField for time
     Serializer<gps_time_t> time_sr;

--- a/src/FCCode/piksi_mode_t.enum
+++ b/src/FCCode/piksi_mode_t.enum
@@ -1,0 +1,23 @@
+#ifndef piksi_mode_t_enum_
+#define piksi_mode_t_enum_
+
+enum class piksi_mode_t {
+  SPP, // Single Point Position
+  FIXED_RTK, // Fixed RTK fix
+  FLOAT_RTK, // Float RTK fix
+
+  NO_FIX, // Insufficient GPS signal for any fix
+  
+  SYNC_ERROR, // Time of weeks not sync'd, 
+  NSAT_ERROR, // #Satellites < 4
+
+  CRC_ERROR, // Corrupted data caused a CRC error
+  TIME_LIMIT_ERROR, // Exceeded 900 microseconds during process_buffer loop
+  DATA_ERROR, // Unexpected data, but otherwise good packet, ex weird flag
+  NO_DATA_ERROR, // No bytes to read from the buffer
+
+  DEAD //Piksi not functional
+
+};
+
+#endif

--- a/src/FCCode/piksi_mode_t.enum
+++ b/src/FCCode/piksi_mode_t.enum
@@ -2,21 +2,21 @@
 #define piksi_mode_t_enum_
 
 enum class piksi_mode_t {
-  SPP, // Single Point Position
-  FIXED_RTK, // Fixed RTK fix
-  FLOAT_RTK, // Float RTK fix
+  spp, // Single Point Position
+  fixed_rtk, // Fixed RTK fix
+  float_rtk, // Float RTK fix
 
-  NO_FIX, // Insufficient GPS signal for any fix
+  no_fix, // Insufficient GPS signal for any fix
   
-  SYNC_ERROR, // Time of weeks not sync'd, 
-  NSAT_ERROR, // #Satellites < 4
+  sync_error, // Time of weeks not sync'd, 
+  nsat_error, // #Satellites < 4
 
-  CRC_ERROR, // Corrupted data caused a CRC error
-  TIME_LIMIT_ERROR, // Exceeded 900 microseconds during process_buffer loop
-  DATA_ERROR, // Unexpected data, but otherwise good packet, ex weird flag
-  NO_DATA_ERROR, // No bytes to read from the buffer
+  crc_error, // Corrupted data caused a CRC error
+  time_limit_error, // Exceeded 900 microseconds during process_buffer loop
+  data_error, // Unexpected data, but otherwise good packet, ex weird flag
+  no_data_error, // No bytes to read from the buffer
 
-  DEAD //Piksi not functional
+  dead //Piksi not functional
 
 };
 

--- a/src/piksi_test.cpp
+++ b/src/piksi_test.cpp
@@ -1,0 +1,16 @@
+#include <Arduino.h>
+#include <Piksi.hpp>
+#include <HardwareSerial.h>
+
+Devices::Piksi piksi("piksi", Serial2);
+
+#ifndef UNIT_TEST
+void setup() {
+    piksi.setup();
+    Serial.begin(9600);
+    delay(2000);
+    Serial.println(piksi.is_functional());
+}
+
+void loop() { }
+#endif

--- a/test/test_fsw_piksi_control_task/test_piksi_control_task.cpp
+++ b/test/test_fsw_piksi_control_task/test_piksi_control_task.cpp
@@ -4,17 +4,11 @@
 #include <unity.h>
 #include <Piksi.hpp>
 
-#include <chrono>
-#include <ctime>
-
 #include "../../src/FCCode/piksi_mode_t.enum"
 
 #define assert_piksi_mode(x) {\
     TEST_ASSERT_EQUAL(x, static_cast<piksi_mode_t>(tf.currentState_fp->get()));\
 }
-
-using namespace Devices;
-
 
 class TestFixture {
     public:
@@ -29,7 +23,7 @@ class TestFixture {
 
         std::unique_ptr<PiksiControlTask> piksi_task;
 
-        Piksi piksi;
+        Devices::Piksi piksi;
         // Create a TestFixture instance of PiksiController with pointers to statefields
         #ifndef DESKTOP
         TestFixture() : registry(), piksi("piksi", Serial4){
@@ -42,6 +36,12 @@ class TestFixture {
                 vel_fp = registry.find_readable_field_t<d_vector_t>("piksi.vel");
                 baseline_fp = registry.find_readable_field_t<d_vector_t>("piksi.baseline_pos");
                 time_fp = registry.find_readable_field_t<gps_time_t>("piksi.time");
+
+                assert(currentState_fp);
+                assert(pos_fp);
+                assert(vel_fp);
+                assert(baseline_fp);
+                assert(time_fp);
         
         }
         #else
@@ -55,6 +55,12 @@ class TestFixture {
                 vel_fp = registry.find_readable_field_t<d_vector_t>("piksi.vel");
                 baseline_fp = registry.find_readable_field_t<d_vector_t>("piksi.baseline_pos");
                 time_fp = registry.find_readable_field_t<gps_time_t>("piksi.time");
+
+                assert(currentState_fp);
+                assert(pos_fp);
+                assert(vel_fp);
+                assert(baseline_fp);
+                assert(time_fp);
         
         }
         #endif
@@ -95,6 +101,7 @@ void test_task_initialization()
         TestFixture tf;
         assert_piksi_mode(piksi_mode_t::no_fix);
 }
+
 void test_read_errors(){
         TestFixture tf;
 

--- a/test/test_fsw_piksi_control_task/test_piksi_control_task.cpp
+++ b/test/test_fsw_piksi_control_task/test_piksi_control_task.cpp
@@ -93,7 +93,7 @@ float mag_2(const std::array<double, 3> input){
 void test_task_initialization()
 {
         TestFixture tf;
-        assert_piksi_mode(piksi_mode_t::NO_FIX);
+        assert_piksi_mode(piksi_mode_t::no_fix);
 }
 void test_read_errors(){
         TestFixture tf;
@@ -101,22 +101,22 @@ void test_read_errors(){
         //read out == 3 means a CRC error occurred
         tf.set_read_return(3);
         tf.execute();
-        assert_piksi_mode(piksi_mode_t::CRC_ERROR);
+        assert_piksi_mode(piksi_mode_t::crc_error);
 
         //read out == 4 means no bytes were in the buffer
         tf.set_read_return(4);
         tf.execute();
-        assert_piksi_mode(piksi_mode_t::NO_DATA_ERROR);
+        assert_piksi_mode(piksi_mode_t::no_data_error);
 
         //read out == 5 means we were processing bytes for more than 900 microseconds
         tf.set_read_return(5);
         tf.execute();
-        assert_piksi_mode(piksi_mode_t::TIME_LIMIT_ERROR);
+        assert_piksi_mode(piksi_mode_t::time_limit_error);
 
         //not cataloged read_return value
         tf.set_read_return(7);
         tf.execute();
-        assert_piksi_mode(piksi_mode_t::DATA_ERROR);
+        assert_piksi_mode(piksi_mode_t::data_error);
     
 }
 
@@ -139,7 +139,7 @@ void test_normal_errors(){
         tf.set_baseline_flag(1);
         tf.execute();
         //should error out because of time inconsistency
-        assert_piksi_mode(piksi_mode_t::SYNC_ERROR);
+        assert_piksi_mode(piksi_mode_t::sync_error);
 
         //insufficient nsats
         tow = 200;
@@ -151,7 +151,7 @@ void test_normal_errors(){
         tf.set_baseline_flag(1);
         tf.execute();
         //times agree, but insufficient nsat
-        assert_piksi_mode(piksi_mode_t::NSAT_ERROR);
+        assert_piksi_mode(piksi_mode_t::nsat_error);
 
         //unexpected baseline flag, should only be 0 or 1
         tow = 200;
@@ -163,7 +163,7 @@ void test_normal_errors(){
         tf.set_baseline_flag(2);
         tf.execute();
         //times agree, but insufficient nsat
-        assert_piksi_mode(piksi_mode_t::DATA_ERROR);
+        assert_piksi_mode(piksi_mode_t::data_error);
 }
 
 //test executions that should yield some sort of fix/lock
@@ -177,7 +177,7 @@ void test_task_execute()
 
         tf.set_read_return(2);
         tf.execute();
-        assert_piksi_mode(piksi_mode_t::NO_FIX);
+        assert_piksi_mode(piksi_mode_t::no_fix);
 
         //fixed RTK
         unsigned int tow = 200;
@@ -189,7 +189,7 @@ void test_task_execute()
         tf.set_baseline_flag(1);
         tf.execute();
         //times should now agree, and be in baseline
-        assert_piksi_mode(piksi_mode_t::FIXED_RTK);
+        assert_piksi_mode(piksi_mode_t::fixed_rtk);
         TEST_ASSERT_TRUE(gps_time_t(0,200,0) == tf.time_fp->get());
         TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(pos),mag_2(tf.pos_fp->get()));
         TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(vel),mag_2(tf.vel_fp->get()));
@@ -209,7 +209,7 @@ void test_task_execute()
         tf.set_baseline_flag(0);
         tf.execute();
         //float rtk test
-        assert_piksi_mode(piksi_mode_t::FLOAT_RTK);
+        assert_piksi_mode(piksi_mode_t::float_rtk);
         TEST_ASSERT_TRUE(gps_time_t(0,300,0) == tf.time_fp->get());
         TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(pos),mag_2(tf.pos_fp->get()));
         TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(vel),mag_2(tf.vel_fp->get()));
@@ -226,7 +226,7 @@ void test_task_execute()
         tf.set_vel_ecef(tow, vel);
         tf.execute();
         //check in SPP
-        assert_piksi_mode(piksi_mode_t::SPP);
+        assert_piksi_mode(piksi_mode_t::spp);
         TEST_ASSERT_TRUE(gps_time_t(0,500,0) == tf.time_fp->get());
         TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(pos),mag_2(tf.pos_fp->get()));
         TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(vel),mag_2(tf.vel_fp->get()));
@@ -251,7 +251,7 @@ void test_dead(){
         tf.set_baseline_flag(1);
         tf.execute();
         //times should now agree, and be in baseline
-        assert_piksi_mode(piksi_mode_t::FIXED_RTK);
+        assert_piksi_mode(piksi_mode_t::fixed_rtk);
         TEST_ASSERT_TRUE(gps_time_t(0,200,0) == tf.time_fp->get());
         TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(pos),mag_2(tf.pos_fp->get()));
         TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(vel),mag_2(tf.vel_fp->get()));
@@ -262,11 +262,11 @@ void test_dead(){
         for(int i = 0;i<1000;i++){
                 tf.execute();
         }
-        assert_piksi_mode(piksi_mode_t::NO_DATA_ERROR);
+        assert_piksi_mode(piksi_mode_t::no_data_error);
 
         //one more execution to throw into DEAD mode
         tf.execute();
-        assert_piksi_mode(piksi_mode_t::DEAD);
+        assert_piksi_mode(piksi_mode_t::dead);
 }
 
 int test_control_task()

--- a/test/test_fsw_piksi_control_task/test_piksi_control_task.cpp
+++ b/test/test_fsw_piksi_control_task/test_piksi_control_task.cpp
@@ -1,0 +1,298 @@
+#include "../StateFieldRegistryMock.hpp"
+
+#include "../../src/FCCode/PiksiControlTask.hpp"
+#include <unity.h>
+#include <Piksi.hpp>
+
+#include <chrono>
+#include <ctime>
+
+#include "../../src/FCCode/piksi_mode_t.enum"
+
+#define assert_piksi_mode(x) {\
+    TEST_ASSERT_EQUAL(x, static_cast<piksi_mode_t>(tf.currentState_fp->get()));\
+}
+
+using namespace Devices;
+
+
+class TestFixture {
+    public:
+        StateFieldRegistryMock registry;
+
+        // pointers to statefields for easy access
+        ReadableStateField<int>* currentState_fp;
+        ReadableStateField<d_vector_t>* pos_fp;
+        ReadableStateField<d_vector_t>* vel_fp;
+        ReadableStateField<d_vector_t>* baseline_fp;
+        ReadableStateField<gps_time_t>* time_fp;
+
+        std::unique_ptr<PiksiControlTask> piksi_task;
+
+        Piksi piksi;
+        // Create a TestFixture instance of PiksiController with pointers to statefields
+        #ifndef DESKTOP
+        TestFixture() : registry(), piksi("piksi", Serial4){
+
+                piksi_task = std::make_unique<PiksiControlTask>(registry, 0, piksi);  
+
+                // initialize pointers to statefields      
+                currentState_fp = registry.find_readable_field_t<int>("piksi.state");
+                pos_fp = registry.find_readable_field_t<d_vector_t>("piksi.pos");
+                vel_fp = registry.find_readable_field_t<d_vector_t>("piksi.vel");
+                baseline_fp = registry.find_readable_field_t<d_vector_t>("piksi.baseline_pos");
+                time_fp = registry.find_readable_field_t<gps_time_t>("piksi.time");
+        
+        }
+        #else
+        TestFixture() : registry(), piksi("piksi"){
+
+                piksi_task = std::make_unique<PiksiControlTask>(registry, 0, piksi);  
+
+                // initialize pointers to statefields      
+                currentState_fp = registry.find_readable_field_t<int>("piksi.state");
+                pos_fp = registry.find_readable_field_t<d_vector_t>("piksi.pos");
+                vel_fp = registry.find_readable_field_t<d_vector_t>("piksi.vel");
+                baseline_fp = registry.find_readable_field_t<d_vector_t>("piksi.baseline_pos");
+                time_fp = registry.find_readable_field_t<gps_time_t>("piksi.time");
+        
+        }
+        #endif
+
+        //method to make calling execute faster
+        void execute(){
+                piksi_task->execute();
+        }
+
+        //set of mocking methods
+        void set_read_return(unsigned int read_out){
+                piksi_task->piksi.set_read_return(read_out);
+        }
+        void set_gps_time(const unsigned int tow){
+                piksi_task->piksi.set_gps_time(tow);
+        }
+        void set_pos_ecef(const unsigned int tow, const std::array<double, 3>& position, const unsigned char nsats){
+                piksi_task->piksi.set_pos_ecef(tow, position, nsats);
+        }
+        void set_vel_ecef(const unsigned int tow, const std::array<double, 3>& velocity){
+                piksi_task->piksi.set_vel_ecef(tow, velocity);
+        }
+        void set_baseline_ecef(const unsigned int tow, const std::array<double, 3>& position){
+                piksi_task->piksi.set_baseline_ecef(tow, position);
+        }
+        void set_baseline_flag(const unsigned char flag){
+                piksi_task->piksi.set_baseline_flag(flag);
+        }
+};
+
+//returns the magnitude^2 of a vector 3 of doubles
+float mag_2(const std::array<double, 3> input){
+        return (float)(input[0]*input[0] + input[1]*input[1] + input[2]*input[2]);
+}
+
+void test_task_initialization()
+{
+        TestFixture tf;
+        assert_piksi_mode(piksi_mode_t::NO_FIX);
+}
+void test_read_errors(){
+        TestFixture tf;
+
+        //read out == 3 means a CRC error occurred
+        tf.set_read_return(3);
+        tf.execute();
+        assert_piksi_mode(piksi_mode_t::CRC_ERROR);
+
+        //read out == 4 means no bytes were in the buffer
+        tf.set_read_return(4);
+        tf.execute();
+        assert_piksi_mode(piksi_mode_t::NO_DATA_ERROR);
+
+        //read out == 5 means we were processing bytes for more than 900 microseconds
+        tf.set_read_return(5);
+        tf.execute();
+        assert_piksi_mode(piksi_mode_t::TIME_LIMIT_ERROR);
+
+        //not cataloged read_return value
+        tf.set_read_return(7);
+        tf.execute();
+        assert_piksi_mode(piksi_mode_t::DATA_ERROR);
+    
+}
+
+//normal errors that come up, but don't mean that the piksi has failed
+void test_normal_errors(){
+        TestFixture tf;
+
+        std::array<double, 3> pos = {1000.0, 2000.0, 3000.0};
+        std::array<double, 3> vel = {4000.0, 5000.0, 6000.0};
+        std::array<double, 3> baseline = {7000.0, 8000.0, 9000.0};
+
+        //tests to make sure to error out if packets not synced to same tow
+        unsigned int tow = 100;
+        unsigned int bad_tow = 200;
+        tf.set_read_return(1);
+        tf.set_gps_time(bad_tow);
+        tf.set_pos_ecef(tow, pos, 4);
+        tf.set_vel_ecef(tow, vel);
+        tf.set_baseline_ecef(tow, baseline);
+        tf.set_baseline_flag(1);
+        tf.execute();
+        //should error out because of time inconsistency
+        assert_piksi_mode(piksi_mode_t::SYNC_ERROR);
+
+        //insufficient nsats
+        tow = 200;
+        tf.set_read_return(1);
+        tf.set_gps_time(tow);
+        tf.set_pos_ecef(tow, pos, 3);
+        tf.set_vel_ecef(tow, vel);
+        tf.set_baseline_ecef(tow, baseline);
+        tf.set_baseline_flag(1);
+        tf.execute();
+        //times agree, but insufficient nsat
+        assert_piksi_mode(piksi_mode_t::NSAT_ERROR);
+
+        //unexpected baseline flag, should only be 0 or 1
+        tow = 200;
+        tf.set_read_return(1);
+        tf.set_gps_time(tow);
+        tf.set_pos_ecef(tow, pos, 4);
+        tf.set_vel_ecef(tow, vel);
+        tf.set_baseline_ecef(tow, baseline);
+        tf.set_baseline_flag(2);
+        tf.execute();
+        //times agree, but insufficient nsat
+        assert_piksi_mode(piksi_mode_t::DATA_ERROR);
+}
+
+//test executions that should yield some sort of fix/lock
+void test_task_execute()
+{
+        TestFixture tf;
+
+        std::array<double, 3> pos = {1000.0, 2000.0, 3000.0};
+        std::array<double, 3> vel = {4000.0, 5000.0, 6000.0};
+        std::array<double, 3> baseline = {7000.0, 8000.0, 9000.0};
+
+        tf.set_read_return(2);
+        tf.execute();
+        assert_piksi_mode(piksi_mode_t::NO_FIX);
+
+        //fixed RTK
+        unsigned int tow = 200;
+        tf.set_read_return(1);
+        tf.set_gps_time(tow);
+        tf.set_pos_ecef(tow, pos, 4);
+        tf.set_vel_ecef(tow, vel);
+        tf.set_baseline_ecef(tow, baseline);
+        tf.set_baseline_flag(1);
+        tf.execute();
+        //times should now agree, and be in baseline
+        assert_piksi_mode(piksi_mode_t::FIXED_RTK);
+        TEST_ASSERT_TRUE(gps_time_t(0,200,0) == tf.time_fp->get());
+        TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(pos),mag_2(tf.pos_fp->get()));
+        TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(vel),mag_2(tf.vel_fp->get()));
+        TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(baseline),mag_2(tf.baseline_fp->get()));
+
+        //float RTK
+        tow = 300;
+        pos = {1200.0, 2200.0, 3200.0};
+        vel = {4200.0, 5200.0, 6200.0};
+        baseline = {7200.0, 8200.0, 9200.0};
+
+        tf.set_read_return(1);
+        tf.set_gps_time(tow);
+        tf.set_pos_ecef(tow, pos, 4);
+        tf.set_vel_ecef(tow, vel);
+        tf.set_baseline_ecef(tow, baseline);
+        tf.set_baseline_flag(0);
+        tf.execute();
+        //float rtk test
+        assert_piksi_mode(piksi_mode_t::FLOAT_RTK);
+        TEST_ASSERT_TRUE(gps_time_t(0,300,0) == tf.time_fp->get());
+        TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(pos),mag_2(tf.pos_fp->get()));
+        TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(vel),mag_2(tf.vel_fp->get()));
+        TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(baseline),mag_2(tf.baseline_fp->get()));
+
+        //SPP check
+        tow = 500;
+        pos = {1230.0, 2230.0, 3230.0};
+        vel = {4230.0, 5230.0, 6230.0};
+
+        tf.set_read_return(0);
+        tf.set_gps_time(tow);
+        tf.set_pos_ecef(tow, pos, 4);
+        tf.set_vel_ecef(tow, vel);
+        tf.execute();
+        //check in SPP
+        assert_piksi_mode(piksi_mode_t::SPP);
+        TEST_ASSERT_TRUE(gps_time_t(0,500,0) == tf.time_fp->get());
+        TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(pos),mag_2(tf.pos_fp->get()));
+        TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(vel),mag_2(tf.vel_fp->get()));
+
+}
+
+//test to make sure the control task goes into dead mode if it happens
+void test_dead(){
+        TestFixture tf;
+
+        std::array<double, 3> pos = {1000.0, 2000.0, 3000.0};
+        std::array<double, 3> vel = {4000.0, 5000.0, 6000.0};
+        std::array<double, 3> baseline = {7000.0, 8000.0, 9000.0};  
+
+        //get a good reading from driver
+        unsigned int tow = 200;
+        tf.set_read_return(1);
+        tf.set_gps_time(tow);
+        tf.set_pos_ecef(tow, pos, 4);
+        tf.set_vel_ecef(tow, vel);
+        tf.set_baseline_ecef(tow, baseline);
+        tf.set_baseline_flag(1);
+        tf.execute();
+        //times should now agree, and be in baseline
+        assert_piksi_mode(piksi_mode_t::FIXED_RTK);
+        TEST_ASSERT_TRUE(gps_time_t(0,200,0) == tf.time_fp->get());
+        TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(pos),mag_2(tf.pos_fp->get()));
+        TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(vel),mag_2(tf.vel_fp->get()));
+        TEST_ASSERT_FLOAT_WITHIN(0.1,mag_2(baseline),mag_2(tf.baseline_fp->get()));
+
+        //simulate that the piksi is not sending any data for 1000 control cycles
+        tf.set_read_return(4);
+        for(int i = 0;i<1000;i++){
+                tf.execute();
+        }
+        assert_piksi_mode(piksi_mode_t::NO_DATA_ERROR);
+
+        //one more execution to throw into DEAD mode
+        tf.execute();
+        assert_piksi_mode(piksi_mode_t::DEAD);
+}
+
+int test_control_task()
+{
+        UNITY_BEGIN();
+        RUN_TEST(test_task_initialization);
+        RUN_TEST(test_read_errors);
+        RUN_TEST(test_normal_errors);
+        RUN_TEST(test_task_execute);
+        RUN_TEST(test_dead);
+        return UNITY_END();
+}
+
+#ifdef DESKTOP
+int main()
+{
+        return test_control_task();
+}
+#else
+#include <Arduino.h>
+void setup()
+{
+        delay(2000);
+        Serial.begin(9600);
+        test_control_task();
+}
+
+void loop() {}
+#endif


### PR DESCRIPTION
This is a PR that encapsulates the Piksi Driver and its Corresponding Control Task.

Within the PiksiController, read_all() is called once, and no memory is stored from cycle to cycle, except an error counter that is reset upon a good reading.

Essentially, barring an extremely long chain of failures, the state of PiksiController is fully determined by the current state of the Piksi. Hopefully, this keeps things simple.

I will make a flow chart of read_all() and the PiksiController execute() soon.