### PR TITLE
Fix the debug task to wait for the sim

### DIFF
--- a/lib/Drivers/Piksi.hpp
+++ b/lib/Drivers/Piksi.hpp
@@ -404,7 +404,6 @@ class Piksi {
     bool _pos_ecef_update;
     bool _baseline_ecef_update;
     bool _vel_ecef_update;
-    bool _iar_update;
     bool _heartbeat_update;
     bool _user_data_update;
 

--- a/src/FCCode/DebugTask.cpp
+++ b/src/FCCode/DebugTask.cpp
@@ -1,26 +1,25 @@
 #include "DebugTask.hpp"
 
 #ifdef HOOTL
-    DebugTask::DebugTask(StateFieldRegistry& registry, unsigned int offset) :
-        TimedControlTask<void>(registry, offset),
-        start_cycle_f("cycle.start", Serializer<bool>())
-    {
-        add_writable_field(start_cycle_f);
-        init();
-    }
+DebugTask::DebugTask(StateFieldRegistry &registry, unsigned int offset)
+    : TimedControlTask<void>(registry, offset),
+      start_cycle_f("cycle.start", Serializer<bool>()) {
+  add_writable_field(start_cycle_f);
+  init();
+}
 #else
-    DebugTask::DebugTask(StateFieldRegistry& registry, unsigned int offset) :
-        TimedControlTask<void>(registry, offset)
-    {
-        init();
-    }
+DebugTask::DebugTask(StateFieldRegistry &registry, unsigned int offset)
+    : TimedControlTask<void>(registry, offset) {
+  init();
+}
 #endif
 
 void DebugTask::execute() {
-    #ifdef HOOTL
-    start_cycle_f.set(false);
-    while(!start_cycle_f.get()) process_commands(_registry);
-    #endif
+#ifdef HOOTL
+  start_cycle_f.set(false);
+  while (!start_cycle_f.get())
+    process_commands(_registry);
+#endif
 }
 
 void DebugTask::init() { debug_console::init(); }

--- a/src/FCCode/DebugTask.cpp
+++ b/src/FCCode/DebugTask.cpp
@@ -1,11 +1,25 @@
 #include "DebugTask.hpp"
 
-DebugTask::DebugTask(StateFieldRegistry& registry, unsigned int offset) :
-    TimedControlTask<void>(registry, offset) { init(); }
+#ifdef HOOTL
+    DebugTask::DebugTask(StateFieldRegistry& registry, unsigned int offset) :
+        TimedControlTask<void>(registry, offset),
+        start_cycle_f("sim.start", Serializer<bool>())
+    {
+        add_writable_field(start_cycle_f);
+        start_cycle_f.set(false);
+        init();
+    }
+#else
+    DebugTask::DebugTask(StateFieldRegistry& registry, unsigned int offset) :
+        TimedControlTask<void>(registry, offset)
+    {
+        init();
+    }
+#endif
 
 void DebugTask::execute() {
     #ifdef HOOTL
-    process_commands(_registry);
+    while(!start_cycle_f.get()) process_commands(_registry);
     #endif
 }
 

--- a/src/FCCode/DebugTask.cpp
+++ b/src/FCCode/DebugTask.cpp
@@ -3,10 +3,9 @@
 #ifdef HOOTL
     DebugTask::DebugTask(StateFieldRegistry& registry, unsigned int offset) :
         TimedControlTask<void>(registry, offset),
-        start_cycle_f("sim.start", Serializer<bool>())
+        start_cycle_f("cycle.start", Serializer<bool>())
     {
         add_writable_field(start_cycle_f);
-        start_cycle_f.set(false);
         init();
     }
 #else
@@ -19,6 +18,7 @@
 
 void DebugTask::execute() {
     #ifdef HOOTL
+    start_cycle_f.set(false);
     while(!start_cycle_f.get()) process_commands(_registry);
     #endif
 }

--- a/src/FCCode/DebugTask.hpp
+++ b/src/FCCode/DebugTask.hpp
@@ -4,31 +4,33 @@
 #include <TimedControlTask.hpp>
 
 class DebugTask : public TimedControlTask<void> {
-   public:
-    /**
-     * @brief Construct a new Debug Task object
-     * 
-     * @param registry 
-     */
-    DebugTask(StateFieldRegistry& registry, unsigned int offset);
+public:
+  /**
+   * @brief Construct a new Debug Task object
+   *
+   * @param registry
+   */
+  DebugTask(StateFieldRegistry &registry, unsigned int offset);
 
-    /**
-     * @brief Runs the debug task (processes state field commands present in the serial buffer.)
-     */
-    void execute() override;
-    
-    /**
-     * @brief Initializes the debug console.
-     */
-    void init();
- 
-  #ifdef HOOTL
-  protected:
-    /**
-     * @brief Flag used by the simulation to keep flight software cycles in sync with the simulation.
-     */
-    WritableStateField<bool> start_cycle_f;
-  #endif
+  /**
+   * @brief Runs the debug task (processes state field commands present in the
+   * serial buffer.)
+   */
+  void execute() override;
+
+  /**
+   * @brief Initializes the debug console.
+   */
+  void init();
+
+#ifdef HOOTL
+protected:
+  /**
+   * @brief Flag used by the simulation to keep flight software cycles in sync
+   * with the simulation.
+   */
+  WritableStateField<bool> start_cycle_f;
+#endif
 };
 
 #endif

--- a/src/FCCode/DebugTask.hpp
+++ b/src/FCCode/DebugTask.hpp
@@ -21,6 +21,14 @@ class DebugTask : public TimedControlTask<void> {
      * @brief Initializes the debug console.
      */
     void init();
+ 
+  #ifdef HOOTL
+  protected:
+    /**
+     * @brief Flag used by the simulation to keep flight software cycles in sync with the simulation.
+     */
+    WritableStateField<bool> start_cycle_f;
+  #endif
 };
 
 #endif

--- a/test/test_real_fsw.py
+++ b/test/test_real_fsw.py
@@ -10,7 +10,7 @@ import serial
 import traceback
 import unittest
 
-class TestDummyFlightSoftwareBinary(unittest.TestCase):
+class TestFlightSoftwareBinary(unittest.TestCase):
     """
     Ensures that basic state field read-write functionality works as expected within
     Flight Software.
@@ -20,25 +20,38 @@ class TestDummyFlightSoftwareBinary(unittest.TestCase):
 
     def setUp(self):
         master_fd, slave_fd = pty.openpty()
-        self.dummy_fsw = subprocess.Popen([self.binary_dir], stdin=master_fd, stdout=master_fd)
+        self.fsw = subprocess.Popen([self.binary_dir], stdin=master_fd, stdout=master_fd)
         self.console = serial.Serial(os.ttyname(slave_fd), 9600, timeout=1)
 
-    def read_cycle_no(self):
+    def readCycleNumber(self):
         input = json.dumps({"field": "pan.cycle_no", "mode" : ord('r')}) + "\n"
         self.console.write(input.encode())
-        response = json.loads(self.console.readline().rstrip())
+
+        line = self.console.readline().rstrip()
+        response = json.loads(line)
         self.assertEqual(response['field'], "pan.cycle_no")
         return int(response['val'])
 
+    def startNextCycle(self):
+        # Send a signal to start the next cycle, like the simulation would.
+        input = json.dumps({"field": "cycle.start", "mode" : ord('w'), "val" : "true"}) + "\n"
+        self.console.write(input.encode())
+        self.console.readline() # Throw away next line
+
     def testValidRead(self):
-        cycle_no = self.read_cycle_no()
-        self.assertGreaterEqual(cycle_no, 0)
-        time.sleep(0.5)
-        new_cycle_no = self.read_cycle_no()
-        self.assertGreater(new_cycle_no, cycle_no)
+        cycleNumber = self.readCycleNumber()
+        self.assertGreaterEqual(cycleNumber, 0)
+
+        self.startNextCycle()
+        newCycleNumber = self.readCycleNumber()
+        self.assertEqual(newCycleNumber, cycleNumber + 1)
+        
+        self.startNextCycle()
+        newCycleNumber = self.readCycleNumber()
+        self.assertEqual(newCycleNumber, cycleNumber + 2)
 
     def tearDown(self):
-        self.dummy_fsw.kill()
+        self.fsw.kill()
         self.console.close()
 
 if __name__ == '__main__':


### PR DESCRIPTION
In order for the sim to work properly, the debug task should wait for the simulation's signal that it's done updating values before allowing the Flight Software to continue executing its cycle. This PR implements that feature.