### PR TITLE
ADCS Estimator Control Task

### DIFF
--- a/src/FCCode/AttitudeEstimator.cpp
+++ b/src/FCCode/AttitudeEstimator.cpp
@@ -3,10 +3,14 @@
 AttitudeEstimator::AttitudeEstimator(StateFieldRegistry &registry,
     unsigned int offset) 
     : TimedControlTask<void>(registry, offset),
+    data(),
+    state(),
+    estimate(),
     q_body_eci_sr(),
     q_body_eci_f("attitude_estimator.q_body_eci", q_body_eci_sr),
-    w_body_sr(),
-    w_body_f("attitude_estimator.w_body", w_body_sr){
+    w_body_sr(0, 1000, 10),
+    w_body_f("attitude_estimator.w_body", w_body_sr)
+    {
 
         //Find pan epoch
         pan_epoch_fp = find_readable_field<gps_time_t>("pan.epoch", __FILE__, __LINE__);
@@ -61,16 +65,16 @@ void AttitudeEstimator::set_data(){
 void AttitudeEstimator::set_estimate(){
 
     f_quat_t q_temp;
-    q_temp[0] = estimate.q_body_eci.operator()[0];
-    q_temp[1] = estimate.q_body_eci.operator()[1];
-    q_temp[2] = estimate.q_body_eci.operator()[2];
-    q_temp[3] = estimate.q_body_eci.operator()[3];
+    q_temp[0] = estimate.q_body_eci.operator()(0);
+    q_temp[1] = estimate.q_body_eci.operator()(1);
+    q_temp[2] = estimate.q_body_eci.operator()(2);
+    q_temp[3] = estimate.q_body_eci.operator()(3);
     q_body_eci_f.set(q_temp);
 
     f_vector_t w_temp;
-    w_temp[0] = estimate.w_body.operator()[0];
-    w_temp[1] = estimate.w_body.operator()[1];
-    w_temp[2] = estimate.w_body.operator()[2];
+    w_temp[0] = estimate.w_body.operator()(0);
+    w_temp[1] = estimate.w_body.operator()(1);
+    w_temp[2] = estimate.w_body.operator()(2);  
     w_body_f.set(w_temp);
 
 }

--- a/src/FCCode/AttitudeEstimator.cpp
+++ b/src/FCCode/AttitudeEstimator.cpp
@@ -22,11 +22,6 @@ AttitudeEstimator::AttitudeEstimator(StateFieldRegistry &registry,
         //find ADCSBoxMonitor inputs
         ssa_vec_rd_fp = find_readable_field<f_vector_t>("adcs_box.sun_vec", __FILE__, __LINE__);
         mag_vec_fp = find_readable_field<f_vector_t>("adcs_box.mag_vec", __FILE__, __LINE__);
-        
-        //create kyles containers?
-        // gnc::AttitudeEstimatorData data;
-        // gnc::AttitudeEstimatorState state;
-        // gnc::AttitudeEstimate estimate;
 
         //Add outputs
         add_readable_field(q_body_eci_f);

--- a/src/FCCode/AttitudeEstimator.cpp
+++ b/src/FCCode/AttitudeEstimator.cpp
@@ -6,9 +6,9 @@ AttitudeEstimator::AttitudeEstimator(StateFieldRegistry &registry,
     data(),
     state(),
     estimate(),
-    q_body_eci_sr(),
+    q_body_eci_sr(0, 1, 22),
     q_body_eci_f("attitude_estimator.q_body_eci", q_body_eci_sr),
-    w_body_sr(0, 1000, 10),
+    w_body_sr(0, 1000, 22),
     w_body_f("attitude_estimator.w_body", w_body_sr)
     {
 

--- a/src/FCCode/AttitudeEstimator.cpp
+++ b/src/FCCode/AttitudeEstimator.cpp
@@ -1,0 +1,78 @@
+#include "AttitudeEstimator.hpp"
+
+AttitudeEstimator::AttitudeEstimator(StateFieldRegistry &registry,
+    unsigned int offset) 
+    : TimedControlTask<void>(registry, offset),
+    q_body_eci_sr(),
+    q_body_eci_f("attitude_estimator.q_body_eci", q_body_eci_sr),
+    w_body_sr(),
+    w_body_f("attitude_estimator.w_body", w_body_sr){
+
+        //Find pan epoch
+        pan_epoch_fp = find_readable_field<gps_time_t>("pan.epoch", __FILE__, __LINE__);
+
+        //Find piksi inputs
+        piksi_time_fp = find_readable_field<gps_time_t>("piksi.time", __FILE__, __LINE__);
+        pos_vec_ecef_fp = find_readable_field<d_vector_t>("piksi.pos", __FILE__, __LINE__);
+
+        //find ADCSBoxMonitor inputs
+        ssa_vec_rd_fp = find_readable_field<f_vector_t>("adcs_box.sun_vec", __FILE__, __LINE__);
+        mag_vec_fp = find_readable_field<f_vector_t>("adcs_box.mag_vec", __FILE__, __LINE__);
+        
+        //create kyles containers?
+        // gnc::AttitudeEstimatorData data;
+        // gnc::AttitudeEstimatorState state;
+        // gnc::AttitudeEstimate estimate;
+
+        //Add outputs
+        add_readable_field(q_body_eci_f);
+        add_readable_field(w_body_f);
+    }
+
+void AttitudeEstimator::execute(){
+    set_data();
+    gnc::estimate_attitude(state, data, estimate);
+    set_estimate();
+}
+
+void AttitudeEstimator::set_data(){
+    data.t = ((double)(unsigned long)(piksi_time_fp->get() - pan_epoch_fp->get()))/(10e9);
+
+    data.r_ecef = lin::Vector3d({
+        pos_vec_ecef_fp->get()[0], 
+        pos_vec_ecef_fp->get()[1], 
+        pos_vec_ecef_fp->get()[2]
+    });
+    
+    data.b_body = lin::Vector3f({
+        mag_vec_fp->get()[0],
+        mag_vec_fp->get()[1],
+        mag_vec_fp->get()[2]
+    });
+
+    data.s_body = lin::Vector3f({
+        ssa_vec_rd_fp->get()[0],
+        ssa_vec_rd_fp->get()[1],
+        ssa_vec_rd_fp->get()[2],
+    });
+
+}
+
+void AttitudeEstimator::set_estimate(){
+
+    f_quat_t q_temp;
+    q_temp[0] = estimate.q_body_eci.operator()[0];
+    q_temp[1] = estimate.q_body_eci.operator()[1];
+    q_temp[2] = estimate.q_body_eci.operator()[2];
+    q_temp[3] = estimate.q_body_eci.operator()[3];
+    q_body_eci_f.set(q_temp);
+
+    f_vector_t w_temp;
+    w_temp[0] = estimate.w_body.operator()[0];
+    w_temp[1] = estimate.w_body.operator()[1];
+    w_temp[2] = estimate.w_body.operator()[2];
+    w_body_f.set(w_temp);
+
+}
+
+    

--- a/src/FCCode/AttitudeEstimator.hpp
+++ b/src/FCCode/AttitudeEstimator.hpp
@@ -1,7 +1,8 @@
 #ifndef ATTITUDE_ESTIMATOR_HPP_
 #define ATTITUDE_ESTIMATOR_HPP_
 
-#include "../../.pio/libdeps/teensy35_hootl/psim/src/gnc_attitude_estimation.cpp"
+#include "../../.pio/libdeps/teensy35_hootl/psim/include/gnc_attitude_estimation.hpp"
+//#include <gnc_attitude_estimation.hpp>
 #include <TimedControlTask.hpp>
 
 /**
@@ -42,25 +43,8 @@ class AttitudeEstimator : public TimedControlTask<void> {
     ReadableStateField<f_vector_t>* ssa_vec_rd_fp;
     //! Magnetic field vector of this satellite in the body frame.
     ReadableStateField<f_vector_t>* mag_vec_fp;
-    
 
-    // /**
-    //  * @brief Constant parameters for calculation.
-    //  */
-    // WritableStateField<f_vector_t> gyro_bias_fp;   /**< Gyroscope bias **/
-    // WritableStateField<f_vector_t> mag_bias_fp;    /**< Magnetometer bias **/
-
-    /**
-     * @brief Estimation outputs.
-     */
-    // //! True if satellite is in eclipse.
-    // ReadableStateField<bool> in_eclipse_f;
-    // //! Spacecraft angular momentum vector, in the body frame.
-    // ReadableStateField<f_vector_t> h_vec_body_f;
-    // //! Quaternion representing the rotation from the body frame to the ECI frame.
-    // ReadableStateField<f_quat_t> body_to_eci_f;
-
-    //kyle's structs
+    //kyle's gnc structs
     gnc::AttitudeEstimatorData data;
     gnc::AttitudeEstimatorState state;
     gnc::AttitudeEstimate estimate;

--- a/src/FCCode/AttitudeEstimator.hpp
+++ b/src/FCCode/AttitudeEstimator.hpp
@@ -1,0 +1,76 @@
+#ifndef ATTITUDE_ESTIMATOR_HPP_
+#define ATTITUDE_ESTIMATOR_HPP_
+
+#include "../../.pio/libdeps/teensy35_hootl/psim/src/gnc_attitude_estimation.cpp"
+#include <TimedControlTask.hpp>
+
+/**
+ * @brief Using raw sensor inputs, determine the attitude and angular state
+ * of the spacecraft.
+ */
+class AttitudeEstimator : public TimedControlTask<void> {
+   public:
+    /**
+     * @brief Construct a new Attitude Estimator.
+     * 
+     * @param registry 
+     */
+    AttitudeEstimator(StateFieldRegistry& registry, unsigned int offset);
+
+    /**
+     * @brief Using raw sensor inputs, determine the attitude and angular state
+     * of the spacecraft.
+     */
+    void execute() override;
+
+    void set_data();
+
+    void set_estimate();
+
+   protected:
+    /**
+     * @brief Inputs collected from Piksi and ADCSBoxMonitor.
+     */
+
+    ReadableStateField<gps_time_t>* pan_epoch_fp;
+
+    //! Time from Piksi
+    ReadableStateField<gps_time_t>* piksi_time_fp;
+    //! Position of this satellite, Vector of doubles
+    ReadableStateField<d_vector_t>* pos_vec_ecef_fp;
+    //! Sun vector of this satellite, in the body frame.
+    ReadableStateField<f_vector_t>* ssa_vec_rd_fp;
+    //! Magnetic field vector of this satellite in the body frame.
+    ReadableStateField<f_vector_t>* mag_vec_fp;
+    
+
+    // /**
+    //  * @brief Constant parameters for calculation.
+    //  */
+    // WritableStateField<f_vector_t> gyro_bias_fp;   /**< Gyroscope bias **/
+    // WritableStateField<f_vector_t> mag_bias_fp;    /**< Magnetometer bias **/
+
+    /**
+     * @brief Estimation outputs.
+     */
+    // //! True if satellite is in eclipse.
+    // ReadableStateField<bool> in_eclipse_f;
+    // //! Spacecraft angular momentum vector, in the body frame.
+    // ReadableStateField<f_vector_t> h_vec_body_f;
+    // //! Quaternion representing the rotation from the body frame to the ECI frame.
+    // ReadableStateField<f_quat_t> body_to_eci_f;
+
+    //kyle's structs
+    gnc::AttitudeEstimatorData data;
+    gnc::AttitudeEstimatorState state;
+    gnc::AttitudeEstimate estimate;
+
+    //AttitudeEstimate
+    Serializer<f_quat_t> q_body_eci_sr;
+    ReadableStateField<f_quat_t> q_body_eci_f;
+    Serializer<f_vector_t> w_body_sr;
+    ReadableStateField<f_vector_t> w_body_f;
+
+};
+
+#endif

--- a/src/FCCode/MainControlLoop.cpp
+++ b/src/FCCode/MainControlLoop.cpp
@@ -26,6 +26,7 @@ MainControlLoop::MainControlLoop(StateFieldRegistry& registry)
       debug_task(registry, debug_task_offset),
       PIKSI_INITIALIZATION,
       piksi_control_task(registry, piksi_control_task_offset, piksi),
+      attitude_estimator(registry, attitude_estimator)
       gomspace(&hk, &config, &config2),
       gomspace_controller(registry, gomspace_controller_offset, gomspace),
       mission_manager(registry, mission_manager_offset),

--- a/src/FCCode/MainControlLoop.cpp
+++ b/src/FCCode/MainControlLoop.cpp
@@ -26,7 +26,7 @@ MainControlLoop::MainControlLoop(StateFieldRegistry& registry)
       debug_task(registry, debug_task_offset),
       PIKSI_INITIALIZATION,
       piksi_control_task(registry, piksi_control_task_offset, piksi),
-      attitude_estimator(registry, attitude_estimator)
+      attitude_estimator(registry, attitude_estimator_offset),
       gomspace(&hk, &config, &config2),
       gomspace_controller(registry, gomspace_controller_offset, gomspace),
       mission_manager(registry, mission_manager_offset),

--- a/src/FCCode/MainControlLoop.hpp
+++ b/src/FCCode/MainControlLoop.hpp
@@ -7,6 +7,7 @@
 
 #include "ClockManager.hpp"
 #include "PiksiControlTask.hpp"
+#include "AttitudeEstimator.hpp"
 #include "GomspaceController.hpp"
 #include "DebugTask.hpp"
 #include "FieldCreatorTask.hpp"
@@ -26,6 +27,7 @@ class MainControlLoop : public ControlTask<void> {
 
     Devices::Piksi piksi;
     PiksiControlTask piksi_control_task;
+    AttitudeEstimator attitude_estimator;
 
     Devices::Gomspace::eps_hk_t hk;
     Devices::Gomspace::eps_config_t config; 
@@ -44,6 +46,7 @@ class MainControlLoop : public ControlTask<void> {
     #ifdef HOOTL
         static constexpr unsigned int debug_task_offset          =   5500;
         static constexpr unsigned int piksi_control_task_offset  =  55000;
+        static constexpr unsigned int attitude_estimator_offset  =  85500;
         static constexpr unsigned int gomspace_controller_offset = 106500;
         static constexpr unsigned int mission_manager_offset     = 111600;
         static constexpr unsigned int docking_controller_offset  = 152400;

--- a/test/test_fsw_adcs/test_fsw_adcs.cpp
+++ b/test/test_fsw_adcs/test_fsw_adcs.cpp
@@ -1,0 +1,30 @@
+#include <unity.h>
+
+void test_adcs_attitude_computer() {}
+void test_adcs_attitude_estimator() {}
+void test_adcs_box_controller() {}
+void test_adcs_box_monitor() {}
+
+int test_adcs_all() {
+    UNITY_BEGIN();
+    RUN_TEST(test_adcs_attitude_computer);
+    RUN_TEST(test_adcs_attitude_estimator);
+    RUN_TEST(test_adcs_box_controller);
+    RUN_TEST(test_adcs_box_monitor);
+    return UNITY_END();
+}
+
+#ifdef DESKTOP
+int main() {
+    return test_adcs_all();
+}
+#else
+#include <Arduino.h>
+void setup() {
+    delay(2000);
+    Serial.begin(9600);
+    test_adcs_all();
+}
+
+void loop() {}
+#endif

--- a/test/test_fsw_attitude_estimator/test_attitude_estimator.cpp
+++ b/test/test_fsw_attitude_estimator/test_attitude_estimator.cpp
@@ -1,0 +1,63 @@
+#include "../StateFieldRegistryMock.hpp"
+
+#include "../../src/FCCode/AttitudeEstimator.hpp"
+#include <unity.h>
+
+class TestFixture {
+    public:
+        StateFieldRegistryMock registry;
+
+        // pointers to statefields for easy access
+        ReadableStateField<f_quat_t>* q_body_eci_fp;
+        ReadableStateField<f_vector_t>* w_body_fp;
+
+        std::unique_ptr<AttitudeEstimator> attitude_estimator;
+
+        // Create a TestFixture instance of AttitudeEstimator with pointers to statefields
+        TestFixture() : registry(){
+
+                attitude_estimator = std::make_unique<AttitudeEstimator>(registry, 0);  
+
+                // initialize pointers to statefields
+                q_body_eci_fp = registry.find_readable_field_t<f_quat_t>("attitude_estimator.q_body_eci");
+                w_body_fp = registry.find_readable_field_t<f_vector_t>("attitude_estimator.w_body");
+
+                assert(q_body_eci_fp);
+                assert(w_body_fp);
+        
+        }
+};
+
+void test_task_initialization()
+{
+        TestFixture tf;
+}
+
+void test_execute(){
+
+}
+
+int test_control_task()
+{
+        UNITY_BEGIN();
+        RUN_TEST(test_task_initialization);
+        RUN_TEST(test_execute);
+        return UNITY_END();
+}
+
+#ifdef DESKTOP
+int main()
+{
+        return test_control_task();
+}
+#else
+#include <Arduino.h>
+void setup()
+{
+        delay(2000);
+        Serial.begin(9600);
+        test_control_task();
+}
+
+void loop() {}
+#endif


### PR DESCRIPTION
This PR creates the AttitudeEstimator Control Task. It finds necessary input state fields, calls Kyle's gnc estimate attitude function and dumps the output into output state fields.