### PR TITLE
ADCS Controller

### DIFF
--- a/src/FCCode/ADCSBoxController.cpp
+++ b/src/FCCode/ADCSBoxController.cpp
@@ -14,7 +14,7 @@ ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry,
 
         rwa_mode_fp = find_writable_field<unsigned char>("adcs_cmd.rwa_mode", __FILE__, __LINE__);
         rwa_speed_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.rwa_speed_cmd", __FILE__, __LINE__);
-        rwa_torque_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.torque_cmd", __FILE__, __LINE__);
+        rwa_torque_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.rwa_torque_cmd", __FILE__, __LINE__);
         rwa_speed_filter_fp = find_writable_field<float>("adcs_cmd.rwa_speed_filter", __FILE__, __LINE__);
         rwa_ramp_filter_fp = find_writable_field<float>("adcs_cmd.rwa_ramp_filter", __FILE__, __LINE__);
 

--- a/src/FCCode/ADCSBoxController.cpp
+++ b/src/FCCode/ADCSBoxController.cpp
@@ -3,12 +3,6 @@
 
 #include <adcs_constants.hpp>
 
-#ifndef isnan
-/* NaN is the only floating point value that does NOT equal itself.
- * Therefore if n != n, then it is NaN. */
-#define isnan(n) ((n != n) ? 1 : 0)
-#endif
-
 ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry, 
     unsigned int offset, Devices::ADCS &_adcs)
     : TimedControlTask<void>(registry, "adcs_controller", offset),
@@ -45,10 +39,6 @@ ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry,
     }
 
 void ADCSBoxController::execute(){
-
-    // define nan
-    const float nan = std::numeric_limits<float>::quiet_NaN();
-
     // set to passive/disabled if in startup
     // consider changing to writeable state_field in adcs box monitor
     if(adcs_state_fp->get() == static_cast<unsigned char>(adcs_state_t::startup))
@@ -65,7 +55,7 @@ void ADCSBoxController::execute(){
     adcs_system.set_mtr_cmd(mtr_cmd_fp->get());
     adcs_system.set_mtr_limit(mtr_limit_fp->get());
 
-    //if calculation is complete/failset the mode to in_progress to begin a new calc
+    //if calculation is complete/fail set the mode to in_progress to begin a new calc
     if(ssa_mode_fp->get() != SSAMode::SSA_IN_PROGRESS)
         adcs_system.set_ssa_mode(SSAMode::SSA_IN_PROGRESS);
     

--- a/src/FCCode/ADCSBoxController.cpp
+++ b/src/FCCode/ADCSBoxController.cpp
@@ -12,8 +12,9 @@ ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry,
         //find command statefields
         adcs_state_fp = find_writable_field<unsigned char>("adcs.state", __FILE__, __LINE__);
 
-        rwa_mode_fp = find_writable_field<unsigned char>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
-        rwa_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
+        rwa_mode_fp = find_writable_field<unsigned char>("adcs_cmd.rwa_mode", __FILE__, __LINE__);
+        rwa_speed_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.rwa_speed_cmd", __FILE__, __LINE__);
+        rwa_torque_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.torque_cmd", __FILE__, __LINE__);
         rwa_speed_filter_fp = find_writable_field<float>("adcs_cmd.rwa_speed_filter", __FILE__, __LINE__);
         rwa_ramp_filter_fp = find_writable_field<float>("adcs_cmd.rwa_ramp_filter", __FILE__, __LINE__);
 
@@ -51,8 +52,15 @@ void ADCSBoxController::execute(){
     else
         adcs_system.set_mode(ADCSMode::ADCS_ACTIVE);
 
-    //dump all commands straight in, ADCS deals with mode    
-    adcs_system.set_rwa_mode(rwa_mode_fp->get(), rwa_cmd_fp->get());
+    // dump all commands
+    if(rwa_mode_fp->get() == RWAMode::RWA_SPEED_CTRL)
+        adcs_system.set_rwa_mode(rwa_mode_fp->get(), rwa_speed_cmd_fp->get());
+    else if(rwa_mode_fp->get() == RWAMode::RWA_ACCEL_CTRL)
+        adcs_system.set_rwa_mode(rwa_mode_fp->get(), rwa_torque_cmd_fp->get());
+    else if(rwa_mode_fp->get() == RWAMode::RWA_DISABLED){
+        adcs_system.set_rwa_mode(rwa_mode_fp->get(), std::array<float, 3>{0,0,0});
+    }
+
     adcs_system.set_rwa_speed_filter(rwa_speed_filter_fp->get());
     adcs_system.set_ramp_filter(rwa_ramp_filter_fp->get());
 

--- a/src/FCCode/ADCSBoxController.cpp
+++ b/src/FCCode/ADCSBoxController.cpp
@@ -46,7 +46,6 @@ ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry,
 
 void ADCSBoxController::execute(){
     // set to passive/disabled if in startup
-    // consider changing to writeable state_field in adcs box monitor
     if(adcs_state_fp->get() == static_cast<unsigned char>(adcs_state_t::startup))
         adcs_system.set_mode(ADCSMode::ADCS_PASSIVE);
     else

--- a/src/FCCode/ADCSBoxController.cpp
+++ b/src/FCCode/ADCSBoxController.cpp
@@ -38,7 +38,7 @@ ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry,
         for(unsigned int idx = adcs_havt::Index::IMU_GYR; idx < adcs_havt::Index::_LENGTH; idx++)
         {
             std::memset(buffer, 0, sizeof(buffer));
-            sprintf(buffer,"adcs_monitor.havt_device");
+            sprintf(buffer,"adcs_cmd.havt_device");
             sprintf(buffer + strlen(buffer), "%u", idx);
             havt_cmd_table_vector_fp.push_back(find_writable_field<bool>(buffer, __FILE__, __LINE__));
         }

--- a/src/FCCode/ADCSBoxController.cpp
+++ b/src/FCCode/ADCSBoxController.cpp
@@ -36,6 +36,9 @@ ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry,
         imu_gyr_temp_ki = find_writable_field<float>("adcs_cmd.imu_temp_ki", __FILE__, __LINE__);
         imu_gyr_temp_kd = find_writable_field<float>("adcs_cmd.imu_temp_kd", __FILE__, __LINE__);
         imu_gyr_temp_desired = find_writable_field<float>("adcs_cmd.imu_gyr_temp_desired", __FILE__, __LINE__);
+    
+        
+        havt_cmd_table_vector_fp = 
     }
 
 void ADCSBoxController::execute(){

--- a/src/FCCode/ADCSBoxController.cpp
+++ b/src/FCCode/ADCSBoxController.cpp
@@ -22,7 +22,6 @@ ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry,
         mtr_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.mtr_cmd", __FILE__, __LINE__);
         mtr_limit_fp = find_writable_field<float>("adcs_cmd.mtr_limit", __FILE__, __LINE__);
 
-        ssa_mode_fp = find_writable_field<unsigned char>("adcs_cmd.ssa_mode", __FILE__, __LINE__);
         ssa_voltage_filter_fp = find_writable_field<float>("adcs_cmd.ssa_voltage_filter", __FILE__, __LINE__);
 
         imu_mode_fp = find_writable_field<unsigned char>("adcs_cmd.imu_mode", __FILE__, __LINE__);

--- a/src/FCCode/ADCSBoxController.cpp
+++ b/src/FCCode/ADCSBoxController.cpp
@@ -12,10 +12,6 @@ ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry,
         //find command statefields
         adcs_state_fp = find_writable_field<unsigned char>("adcs.state", __FILE__, __LINE__);
 
-        /**
-         * @brief RWA commands
-         * 
-         */
         rwa_mode_fp = find_writable_field<unsigned char>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
         rwa_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
         rwa_speed_filter_fp = find_writable_field<float>("adcs_cmd.rwa_speed_filter", __FILE__, __LINE__);
@@ -25,7 +21,6 @@ ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry,
         mtr_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.mtr_cmd", __FILE__, __LINE__);
         mtr_limit_fp = find_writable_field<float>("adcs_cmd.mtr_limit", __FILE__, __LINE__);
 
-        //consider changing ssa_mode in box monitor to writable to use same field
         ssa_mode_fp = find_writable_field<unsigned char>("adcs_cmd.ssa_mode", __FILE__, __LINE__);
         ssa_voltage_filter_fp = find_writable_field<float>("adcs_cmd.ssa_voltage_filter", __FILE__, __LINE__);
 

--- a/src/FCCode/ADCSBoxController.cpp
+++ b/src/FCCode/ADCSBoxController.cpp
@@ -1,0 +1,123 @@
+#include "ADCSBoxMonitor.hpp"
+
+#include <adcs_constants.hpp>
+
+ADCSBoxMonitor::ADCSBoxMonitor(StateFieldRegistry &registry, 
+    unsigned int offset, Devices::ADCS &_adcs)
+    : TimedControlTask<void>(registry, "adcs_monitor", offset),
+    adcs_system(_adcs),
+    rwa_speed_rd_sr(rwa::min_speed_read, rwa::max_speed_read, 16*3), //referenced from I2C_Interface.doc
+    rwa_speed_rd_f("adcs_monitor.rwa_speed_rd", rwa_speed_rd_sr),
+    rwa_torque_rd_sr(rwa::min_torque, rwa::max_torque, 16*3), //referenced from I2C_Interface.doc
+    rwa_torque_rd_f("adcs_monitor.rwa_torque_rd", rwa_torque_rd_sr),
+    ssa_mode_rd(0,2,2), //referenced from Interface.doc
+    ssa_mode_f("adcs_monitor.ssa_mode", ssa_mode_rd),
+    ssa_vec_sr(-1,1,16*3), //referenced from I2C_Interface.doc
+    ssa_vec_f("adcs_monitor.ssa_vec", ssa_vec_sr),
+    ssa_voltage_sr(ssa::min_voltage_rd, ssa::max_voltage_rd, 8),
+    ssa_voltages_f(),
+    mag_vec_sr(imu::min_rd_mag, imu::max_rd_mag, 16*3), //referenced from I2C_Interface.doc
+    mag_vec_f("adcs_monitor.mag_vec", mag_vec_sr),
+    gyr_vec_sr(imu::min_rd_omega, imu::max_rd_omega, 16*3), //referenced from I2C_Interface.doc
+    gyr_vec_f("adcs_monitor.gyr_vec", gyr_vec_sr),
+    gyr_temp_sr(ssa::min_voltage_rd, ssa::max_voltage_rd, 16), //referenced from I2C_Interface.doc
+    gyr_temp_f("adcs_monitor.gyr_temp", gyr_temp_sr),
+    {
+        //fill vector of statefields
+        char buffer[50];
+        for(unsigned int i = 0; i<ssa::num_sun_sensors;i++){
+            std::memset(buffer, 0, sizeof(buffer));
+            sprintf(buffer,"adcs_monitor.ssa_voltage");
+            sprintf(buffer + strlen(buffer), "%u", i);
+            ssa_voltages_f.push_back(ReadableStateField<float>(buffer, ssa_voltage_sr));
+        }
+
+        //actually add statefields to registry
+        add_readable_field(rwa_speed_rd_f);
+        add_readable_field(rwa_torque_rd_f);
+        add_readable_field(ssa_mode_f);
+        add_readable_field(ssa_vec_f);
+
+        for(unsigned int i = 0; i<ssa::num_sun_sensors; i++){
+            add_readable_field(ssa_voltages_f[i]);
+        }
+
+        add_readable_field(mag_vec_f);
+        add_readable_field(gyr_vec_f);
+        add_readable_field(gyr_temp_f);
+
+        //add flag state fields
+        add_readable_field(rwa_speed_rd_flag);
+        add_readable_field(rwa_torque_rd_flag);
+        add_readable_field(mag_vec_flag);
+        add_readable_field(gyr_vec_flag);
+        add_readable_field(gyr_temp_flag);
+    }
+
+void ADCSBoxMonitor::execute(){
+
+    //define nan
+    const float nan = std::numeric_limits<float>::quiet_NaN();
+
+    //create internal containers to read data
+    f_vector_t rwa_speed_rd;
+    f_vector_t rwa_torque_rd;
+    unsigned char ssa_mode = 0;
+    f_vector_t ssa_vec;
+
+    std::array<float, ssa::num_sun_sensors> ssa_voltages;
+    ssa_voltages.fill(0);
+
+    f_vector_t mag_vec;
+    f_vector_t gyr_vec;
+    float gyr_temp = 0.0;
+
+    //ask the driver to fill in values
+    adcs_system.get_rwa(&rwa_speed_rd,&rwa_torque_rd);
+    adcs_system.get_ssa_voltage(&ssa_voltages);
+    adcs_system.get_imu(&mag_vec, &gyr_vec, &gyr_temp);
+
+    //only update the ssa_vector if and only if the mode was COMPLETE
+    adcs_system.get_ssa_mode(&ssa_mode);
+    if(ssa_mode == SSAMode::SSA_COMPLETE){
+        adcs_system.get_ssa_vector(&ssa_vec);
+        ssa_vec_f.set(ssa_vec);
+    }
+    else{
+        ssa_vec_f.set({nan,nan,nan});
+    }
+    
+    //set statefields from internal containers
+    rwa_speed_rd_f.set(rwa_speed_rd);
+    rwa_torque_rd_f.set(rwa_torque_rd);
+    ssa_mode_f.set(ssa_mode);
+
+    for(int i = 0; i<ssa::num_sun_sensors; i++){
+        ssa_voltages_f[i].set(ssa_voltages[i]);
+    }
+
+    mag_vec_f.set(mag_vec);
+    gyr_vec_f.set(gyr_vec);
+    gyr_temp_f.set(gyr_temp);
+
+    //flags default to false, meaning there are no issues
+    rwa_speed_rd_flag.set(false);
+    rwa_torque_rd_flag.set(false);
+    mag_vec_flag.set(false);
+    gyr_vec_flag.set(false);
+    gyr_temp_flag.set(false);
+
+    //TODO: UPDATE; THESE ARE PLACE HOLDER FLAG BOUNDS
+    //They all have bounds of min to max -1 to force a flag for testing purposes
+    //Eventually change to proper bounds
+    if(exceed_bounds(rwa_speed_rd, rwa::min_speed_read, rwa::max_speed_read - 1))
+        rwa_speed_rd_flag.set(true);
+    if(exceed_bounds(rwa_torque_rd, rwa::min_torque, rwa::max_torque - 1))
+        rwa_torque_rd_flag.set(true);
+    if(exceed_bounds(mag_vec, imu::min_rd_mag, imu::max_rd_mag - 1))
+        mag_vec_flag.set(true);
+    if(exceed_bounds(gyr_vec, imu::min_rd_omega, imu::max_rd_omega - 1))
+        gyr_vec_flag.set(true);
+    if(exceed_bounds(gyr_temp, imu::min_rd_temp, imu::max_rd_temp - 1))
+        gyr_temp_flag.set(true);
+}

--- a/src/FCCode/ADCSBoxController.cpp
+++ b/src/FCCode/ADCSBoxController.cpp
@@ -14,7 +14,6 @@ ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry,
     : TimedControlTask<void>(registry, "adcs_controller", offset),
     adcs_system(_adcs)
     {
-
         //find command statefields
         adcs_state_fp = find_writable_field<unsigned char>("adcs.state", __FILE__, __LINE__);
 
@@ -57,15 +56,6 @@ void ADCSBoxController::execute(){
     else
         adcs_system.set_mode(ADCSMode::ADCS_ACTIVE);
 
-    // update ssa calc mode
-    // BLOCK O' CODE
-
-    // apply commands
-    // rwa_mode_fp = find_writable_field<unsigned char>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
-    // rwa_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
-    // rwa_speed_filter_fp = find_writable_field<float>("adcs_cmd.rwa_speed_filter", __FILE__, __LINE__);
-    // rwa_ramp_filter_fp = find_writable_field<float>("adcs_cmd.rwa_ramp_filter", __FILE__, __LINE__);
-
     //dump all commands straight in, ADCS deals with mode    
     adcs_system.set_rwa_mode(rwa_mode_fp->get(), rwa_cmd_fp->get());
     adcs_system.set_rwa_speed_filter(rwa_speed_filter_fp->get());
@@ -76,7 +66,7 @@ void ADCSBoxController::execute(){
     adcs_system.set_mtr_limit(mtr_limit_fp->get());
 
     //if calculation is complete/failset the mode to in_progress to begin a new calc
-    if(ssa_mode_fp->get() != SSAMode:;SSA_IN_PROGRESS)
+    if(ssa_mode_fp->get() != SSAMode::SSA_IN_PROGRESS)
         adcs_system.set_ssa_mode(SSAMode::SSA_IN_PROGRESS);
     
     adcs_system.set_ssa_voltage_filter(ssa_voltage_filter_fp->get());
@@ -89,14 +79,4 @@ void ADCSBoxController::execute(){
     adcs_system.set_imu_gyr_temp_ki(imu_gyr_temp_ki->get());
     adcs_system.set_imu_gyr_temp_kd(imu_gyr_temp_kd->get());
     adcs_system.set_imu_gyr_temp_desired(imu_gyr_temp_desired->get());
-    
-    imu_mode_fp = find_writable_field<unsigned char>("adcs_cmd.imu_mode", __FILE__, __LINE__);
-    imu_mag_filter_fp = find_writable_field<float>("adcs_cmd.imu_mag_filter", __FILE__, __LINE__);
-    imu_gyr_filter_fp = find_writable_field<float>("adcs_cmd.imu_gyr_filter", __FILE__, __LINE__);
-    imu_gyr_temp_filter_fp = find_writable_field<float>("adcs_cmd.imu_gyr_temp_filter", __FILE__, __LINE__);
-    imu_gyr_temp_kp = find_writable_field<float>("adcs_cmd.imu_temp_kp", __FILE__, __LINE__);
-    imu_gyr_temp_ki = find_writable_field<float>("adcs_cmd.imu_temp_ki", __FILE__, __LINE__);
-    imu_gyr_temp_kd = find_writable_field<float>("adcs_cmd.imu_temp_kd", __FILE__, __LINE__);
-    imu_gyr_temp_desired = find_writable_field<float>("adcs_cmd.imu_gyr_temp_desired", __FILE__, __LINE__);
-
 }

--- a/src/FCCode/ADCSBoxController.cpp
+++ b/src/FCCode/ADCSBoxController.cpp
@@ -38,7 +38,7 @@ ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry,
         for(unsigned int idx = adcs_havt::Index::IMU_GYR; idx < adcs_havt::Index::_LENGTH; idx++)
         {
             std::memset(buffer, 0, sizeof(buffer));
-            sprintf(buffer,"adcs_cmd.havt_device");
+            sprintf(buffer,"adcs_monitor.havt_device");
             sprintf(buffer + strlen(buffer), "%u", idx);
             havt_cmd_table_vector_fp.push_back(find_writable_field<bool>(buffer, __FILE__, __LINE__));
         }

--- a/src/FCCode/ADCSBoxController.cpp
+++ b/src/FCCode/ADCSBoxController.cpp
@@ -1,123 +1,49 @@
-#include "ADCSBoxMonitor.hpp"
+#include "ADCSBoxController.hpp"
+#include "adcs_state_t.enum"
 
 #include <adcs_constants.hpp>
 
-ADCSBoxMonitor::ADCSBoxMonitor(StateFieldRegistry &registry, 
+ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry, 
     unsigned int offset, Devices::ADCS &_adcs)
-    : TimedControlTask<void>(registry, "adcs_monitor", offset),
-    adcs_system(_adcs),
-    rwa_speed_rd_sr(rwa::min_speed_read, rwa::max_speed_read, 16*3), //referenced from I2C_Interface.doc
-    rwa_speed_rd_f("adcs_monitor.rwa_speed_rd", rwa_speed_rd_sr),
-    rwa_torque_rd_sr(rwa::min_torque, rwa::max_torque, 16*3), //referenced from I2C_Interface.doc
-    rwa_torque_rd_f("adcs_monitor.rwa_torque_rd", rwa_torque_rd_sr),
-    ssa_mode_rd(0,2,2), //referenced from Interface.doc
-    ssa_mode_f("adcs_monitor.ssa_mode", ssa_mode_rd),
-    ssa_vec_sr(-1,1,16*3), //referenced from I2C_Interface.doc
-    ssa_vec_f("adcs_monitor.ssa_vec", ssa_vec_sr),
-    ssa_voltage_sr(ssa::min_voltage_rd, ssa::max_voltage_rd, 8),
-    ssa_voltages_f(),
-    mag_vec_sr(imu::min_rd_mag, imu::max_rd_mag, 16*3), //referenced from I2C_Interface.doc
-    mag_vec_f("adcs_monitor.mag_vec", mag_vec_sr),
-    gyr_vec_sr(imu::min_rd_omega, imu::max_rd_omega, 16*3), //referenced from I2C_Interface.doc
-    gyr_vec_f("adcs_monitor.gyr_vec", gyr_vec_sr),
-    gyr_temp_sr(ssa::min_voltage_rd, ssa::max_voltage_rd, 16), //referenced from I2C_Interface.doc
-    gyr_temp_f("adcs_monitor.gyr_temp", gyr_temp_sr),
+    : TimedControlTask<void>(registry, "adcs_controller", offset),
+    adcs_system(_adcs)
     {
-        //fill vector of statefields
-        char buffer[50];
-        for(unsigned int i = 0; i<ssa::num_sun_sensors;i++){
-            std::memset(buffer, 0, sizeof(buffer));
-            sprintf(buffer,"adcs_monitor.ssa_voltage");
-            sprintf(buffer + strlen(buffer), "%u", i);
-            ssa_voltages_f.push_back(ReadableStateField<float>(buffer, ssa_voltage_sr));
-        }
 
-        //actually add statefields to registry
-        add_readable_field(rwa_speed_rd_f);
-        add_readable_field(rwa_torque_rd_f);
-        add_readable_field(ssa_mode_f);
-        add_readable_field(ssa_vec_f);
+        //find command statefields
+        adcs_state_fp = find_writable_field<unsigned char>("adcs.state", __FILE__, __LINE__);
 
-        for(unsigned int i = 0; i<ssa::num_sun_sensors; i++){
-            add_readable_field(ssa_voltages_f[i]);
-        }
+        const WritableStateField<unsigned char>* mtr_mode_fp;
+        const WritableStateField<f_vector_t>* mtr_cmd_fp;
+        const WritableStateField<float>* mtr_limit_fp;
 
-        add_readable_field(mag_vec_f);
-        add_readable_field(gyr_vec_f);
-        add_readable_field(gyr_temp_f);
+        //perhaps change box monitor to a writeable statefield
+        const WritableStateField<unsigned char>* ssa_mode_fp;
 
-        //add flag state fields
-        add_readable_field(rwa_speed_rd_flag);
-        add_readable_field(rwa_torque_rd_flag);
-        add_readable_field(mag_vec_flag);
-        add_readable_field(gyr_vec_flag);
-        add_readable_field(gyr_temp_flag);
+        //consider changing
+        ssa_mode_fp = find_writable_field<unsigned char>("adcs_cmd.ssa_mode", __FILE__, __LINE__);
+        ssa_voltage_filter_fp = find_writable_field<float>("adcs_cmd.ssa_voltage_filter", __FILE__, __LINE__);
+
+        imu_mode_fp = find_writable_field<unsigned char>("adcs_cmd.imu_mode", __FILE__, __LINE__);
+        imu_mag_filter_fp = find_writable_field<float>("adcs_cmd.imu_mag_filter", __FILE__, __LINE__);
+        imu_gyr_filter_fp = find_writable_field<float>("adcs_cmd.imu_gyr_filter", __FILE__, __LINE__);
+        imu_gyr_temp_filter_fp = find_writable_field<float>("adcs_cmd.imu_gyr_temp_filter", __FILE__, __LINE__);
+        imu_gyr_temp_kp = find_writable_field<float>("adcs_cmd.imu_temp_kp", __FILE__, __LINE__);
+        imu_gyr_temp_ki = find_writable_field<float>("adcs_cmd.imu_temp_ki", __FILE__, __LINE__);
+        imu_gyr_temp_kd = find_writable_field<float>("adcs_cmd.imu_temp_kd", __FILE__, __LINE__);
+        imu_gyr_temp_desired = find_writable_field<float>("adcs_cmd.imu_gyr_temp_desired", __FILE__, __LINE__);
     }
 
-void ADCSBoxMonitor::execute(){
+void ADCSBoxController::execute(){
 
     //define nan
     const float nan = std::numeric_limits<float>::quiet_NaN();
 
-    //create internal containers to read data
-    f_vector_t rwa_speed_rd;
-    f_vector_t rwa_torque_rd;
-    unsigned char ssa_mode = 0;
-    f_vector_t ssa_vec;
-
-    std::array<float, ssa::num_sun_sensors> ssa_voltages;
-    ssa_voltages.fill(0);
-
-    f_vector_t mag_vec;
-    f_vector_t gyr_vec;
-    float gyr_temp = 0.0;
-
-    //ask the driver to fill in values
-    adcs_system.get_rwa(&rwa_speed_rd,&rwa_torque_rd);
-    adcs_system.get_ssa_voltage(&ssa_voltages);
-    adcs_system.get_imu(&mag_vec, &gyr_vec, &gyr_temp);
-
-    //only update the ssa_vector if and only if the mode was COMPLETE
-    adcs_system.get_ssa_mode(&ssa_mode);
-    if(ssa_mode == SSAMode::SSA_COMPLETE){
-        adcs_system.get_ssa_vector(&ssa_vec);
-        ssa_vec_f.set(ssa_vec);
+    if(adcs_state_fp->get() != adcs_state_t::startup){
+        //enable the adcs_box
     }
-    else{
-        ssa_vec_f.set({nan,nan,nan});
-    }
-    
-    //set statefields from internal containers
-    rwa_speed_rd_f.set(rwa_speed_rd);
-    rwa_torque_rd_f.set(rwa_torque_rd);
-    ssa_mode_f.set(ssa_mode);
+    else
+        //disable adcs box
 
-    for(int i = 0; i<ssa::num_sun_sensors; i++){
-        ssa_voltages_f[i].set(ssa_voltages[i]);
-    }
+    //update ssa calc mode
 
-    mag_vec_f.set(mag_vec);
-    gyr_vec_f.set(gyr_vec);
-    gyr_temp_f.set(gyr_temp);
-
-    //flags default to false, meaning there are no issues
-    rwa_speed_rd_flag.set(false);
-    rwa_torque_rd_flag.set(false);
-    mag_vec_flag.set(false);
-    gyr_vec_flag.set(false);
-    gyr_temp_flag.set(false);
-
-    //TODO: UPDATE; THESE ARE PLACE HOLDER FLAG BOUNDS
-    //They all have bounds of min to max -1 to force a flag for testing purposes
-    //Eventually change to proper bounds
-    if(exceed_bounds(rwa_speed_rd, rwa::min_speed_read, rwa::max_speed_read - 1))
-        rwa_speed_rd_flag.set(true);
-    if(exceed_bounds(rwa_torque_rd, rwa::min_torque, rwa::max_torque - 1))
-        rwa_torque_rd_flag.set(true);
-    if(exceed_bounds(mag_vec, imu::min_rd_mag, imu::max_rd_mag - 1))
-        mag_vec_flag.set(true);
-    if(exceed_bounds(gyr_vec, imu::min_rd_omega, imu::max_rd_omega - 1))
-        gyr_vec_flag.set(true);
-    if(exceed_bounds(gyr_temp, imu::min_rd_temp, imu::max_rd_temp - 1))
-        gyr_temp_flag.set(true);
 }

--- a/src/FCCode/ADCSBoxController.hpp
+++ b/src/FCCode/ADCSBoxController.hpp
@@ -79,7 +79,7 @@ protected:
      * @brief HAVT command table, a vector of pointers to bool state fields
      * 
      */
-    std::vector<WritableStateField<bool>*> havt_cmd_table_vector_fp;
+    std::vector<const WritableStateField<bool>*> havt_cmd_table_vector_fp;
 
 };
 

--- a/src/FCCode/ADCSBoxController.hpp
+++ b/src/FCCode/ADCSBoxController.hpp
@@ -8,6 +8,7 @@
  * @brief Takes input command statefields and commands the ADCS Box.
  * 
  * Note this CT doesn't do any computing, just actuation
+ * This CT is inteded to only do hardware calls
  */
 class ADCSBoxController : public TimedControlTask<void>
 {
@@ -25,8 +26,7 @@ public:
     Devices::ADCS& adcs_system;
 
     /**
-    * @brief Gets inputs from the ADCS box and dumps them into the state
-    * fields listed below.
+    * @brief Given the command statefields, use the ADCS driver to execute
     */
     void execute() override;
 
@@ -34,11 +34,15 @@ protected:
     /**
     * @brief Commands to actuate on the ADCS Box
     */
-   
+
+    /**
+     * @brief Command to get from mission_manager
+     * 
+     */
     const WritableStateField<unsigned char>* adcs_state_fp;
 
     /**
-     * @brief RWA commands
+     * @brief RWA command fields
      * 
      */
     const WritableStateField<unsigned char>* rwa_mode_fp;
@@ -47,20 +51,22 @@ protected:
     const WritableStateField<float>* rwa_ramp_filter_fp;
 
     /**
-     * @brief MTR commands
+     * @brief MTR command fields
      * 
      */
     const WritableStateField<unsigned char>* mtr_mode_fp;
     const WritableStateField<f_vector_t>* mtr_cmd_fp;
     const WritableStateField<float>* mtr_limit_fp;
 
-    //perhaps change box monitor to a writeable statefield
+    /**
+     * @brief SSA command fields
+     * 
+     */
     const WritableStateField<unsigned char>* ssa_mode_fp;
-
     const WritableStateField<float>* ssa_voltage_filter_fp;
 
     /**
-     * @brief IMU commands
+     * @brief IMU command fields
      * 
      */
     const WritableStateField<unsigned char>* imu_mode_fp;

--- a/src/FCCode/ADCSBoxController.hpp
+++ b/src/FCCode/ADCSBoxController.hpp
@@ -42,7 +42,8 @@ protected:
      * 
      */
     const WritableStateField<unsigned char>* rwa_mode_fp;
-    const WritableStateField<f_vector_t>* rwa_cmd_fp;
+    const WritableStateField<f_vector_t>* rwa_speed_cmd_fp;
+    const WritableStateField<f_vector_t>* rwa_torque_cmd_fp;
     const WritableStateField<float>* rwa_speed_filter_fp;
     const WritableStateField<float>* rwa_ramp_filter_fp;
 

--- a/src/FCCode/ADCSBoxController.hpp
+++ b/src/FCCode/ADCSBoxController.hpp
@@ -32,10 +32,6 @@ public:
 
 protected:
     /**
-    * @brief Commands to actuate on the ADCS Box
-    */
-
-    /**
      * @brief Command to get from mission_manager
      * 
      */
@@ -78,6 +74,10 @@ protected:
     const WritableStateField<float>* imu_gyr_temp_kd_fp;
     const WritableStateField<float>* imu_gyr_temp_desired_fp;
 
+    /**
+     * @brief HAVT command table, a vector of pointers to bool state fields
+     * 
+     */
     std::vector<WritableStateField<bool>*> havt_cmd_table_vector_fp;
 
 };

--- a/src/FCCode/ADCSBoxController.hpp
+++ b/src/FCCode/ADCSBoxController.hpp
@@ -34,7 +34,43 @@ protected:
     /**
     * @brief Commands to actuate on the ADCS Box
     */
-    ReadableStateField<bool>* adcs_mode_fp;
+   
+    const WritableStateField<unsigned char>* adcs_state_fp;
+
+    /**
+     * @brief RWA commands
+     * 
+     */
+    const WritableStateField<unsigned char>* rwa_mode_fp;
+    const WritableStateField<f_vector_t>* rwa_cmd_fp;
+    const WritableStateField<float>* rwa_speed_filter_fp;
+    const WritableStateField<float>* rwa_ramp_filter_fp;
+
+    /**
+     * @brief MTR commands
+     * 
+     */
+    const WritableStateField<unsigned char>* mtr_mode_fp;
+    const WritableStateField<f_vector_t>* mtr_cmd_fp;
+    const WritableStateField<float>* mtr_limit_fp;
+
+    //perhaps change box monitor to a writeable statefield
+    const WritableStateField<unsigned char>* ssa_mode_fp;
+
+    const WritableStateField<float>* ssa_voltage_filter_fp;
+
+    /**
+     * @brief IMU commands
+     * 
+     */
+    const WritableStateField<unsigned char>* imu_mode_fp;
+    const WritableStateField<float>* imu_mag_filter_fp;
+    const WritableStateField<float>* imu_gyr_filter_fp;
+    const WritableStateField<float>* imu_gyr_temp_filter_fp;
+    const WritableStateField<float>* imu_gyr_temp_kp;
+    const WritableStateField<float>* imu_gyr_temp_ki;
+    const WritableStateField<float>* imu_gyr_temp_kd;
+    const WritableStateField<float>* imu_gyr_temp_desired;
 };
 
 #endif

--- a/src/FCCode/ADCSBoxController.hpp
+++ b/src/FCCode/ADCSBoxController.hpp
@@ -77,6 +77,9 @@ protected:
     const WritableStateField<float>* imu_gyr_temp_ki;
     const WritableStateField<float>* imu_gyr_temp_kd;
     const WritableStateField<float>* imu_gyr_temp_desired;
+
+    std::vector<WritableStateField<float>*> havt_cmd_table_vector_fp;
+
 };
 
 #endif

--- a/src/FCCode/ADCSBoxController.hpp
+++ b/src/FCCode/ADCSBoxController.hpp
@@ -1,0 +1,40 @@
+#ifndef ADCS_BOX_CONTROLLER_HPP_
+#define ADCS_BOX_CONTROLLER_HPP_
+
+#include <ADCS.hpp>
+#include "TimedControlTask.hpp"
+
+/**
+ * @brief Takes input command statefields and commands the ADCS Box.
+ * 
+ * Note this CT doesn't do any computing, just actuation
+ */
+class ADCSBoxController : public TimedControlTask<void>
+{
+public:
+    /**
+     * @brief Construct a new ADCSBoxController control task
+     * 
+     * @param registry input StateField registry
+     * @param offset control task offset
+     * @param _adcs the input adcs system
+     */
+    ADCSBoxController(StateFieldRegistry &registry, unsigned int offset, Devices::ADCS &_adcs);
+
+    /** ADCS Driver. **/
+    Devices::ADCS& adcs_system;
+
+    /**
+    * @brief Gets inputs from the ADCS box and dumps them into the state
+    * fields listed below.
+    */
+    void execute() override;
+
+protected:
+    /**
+    * @brief Commands to actuate on the ADCS Box
+    */
+    ReadableStateField<bool>* adcs_mode_fp;
+};
+
+#endif

--- a/src/FCCode/ADCSBoxController.hpp
+++ b/src/FCCode/ADCSBoxController.hpp
@@ -73,12 +73,12 @@ protected:
     const WritableStateField<float>* imu_mag_filter_fp;
     const WritableStateField<float>* imu_gyr_filter_fp;
     const WritableStateField<float>* imu_gyr_temp_filter_fp;
-    const WritableStateField<float>* imu_gyr_temp_kp;
-    const WritableStateField<float>* imu_gyr_temp_ki;
-    const WritableStateField<float>* imu_gyr_temp_kd;
-    const WritableStateField<float>* imu_gyr_temp_desired;
+    const WritableStateField<float>* imu_gyr_temp_kp_fp;
+    const WritableStateField<float>* imu_gyr_temp_ki_fp;
+    const WritableStateField<float>* imu_gyr_temp_kd_fp;
+    const WritableStateField<float>* imu_gyr_temp_desired_fp;
 
-    std::vector<WritableStateField<float>*> havt_cmd_table_vector_fp;
+    std::vector<WritableStateField<bool>*> havt_cmd_table_vector_fp;
 
 };
 

--- a/src/FCCode/FieldCreatorTask.hpp
+++ b/src/FCCode/FieldCreatorTask.hpp
@@ -25,29 +25,29 @@ class FieldCreatorTask : public ControlTask<void> {
       // begin fields necessary for adcs_box controller
       const Serializer<float> filter_sr;
 
-      const WritableStateField<unsigned char> rwa_mode_f;
-      const WritableStateField<f_vector_t> rwa_speed_cmd_f;
-      const WritableStateField<f_vector_t> rwa_torque_cmd_f;
-      const WritableStateField<float> rwa_speed_filter_f;
-      const WritableStateField<float> rwa_ramp_filter_f;
+      WritableStateField<unsigned char> rwa_mode_f;
+      WritableStateField<f_vector_t> rwa_speed_cmd_f;
+      WritableStateField<f_vector_t> rwa_torque_cmd_f;
+      WritableStateField<float> rwa_speed_filter_f;
+      WritableStateField<float> rwa_ramp_filter_f;
 
-      const WritableStateField<unsigned char> mtr_mode_f;
-      const WritableStateField<f_vector_t> mtr_cmd_f;
-      const WritableStateField<float> mtr_limit_f;
+      WritableStateField<unsigned char> mtr_mode_f;
+      WritableStateField<f_vector_t> mtr_cmd_f;
+      WritableStateField<float> mtr_limit_f;
 
-      const WritableStateField<float> ssa_voltage_filter_f;
+      WritableStateField<float> ssa_voltage_filter_f;
 
-      const WritableStateField<unsigned char> imu_mode_f;
-      const WritableStateField<float> imu_mag_filter_f;
-      const WritableStateField<float> imu_gyr_filter_f;
-      const WritableStateField<float> imu_gyr_temp_filter_f;
+      WritableStateField<unsigned char> imu_mode_f;
+      WritableStateField<float> imu_mag_filter_f;
+      WritableStateField<float> imu_gyr_filter_f;
+      WritableStateField<float> imu_gyr_temp_filter_f;
 
       const Serializer<float> k_sr;
 
-      const WritableStateField<float> imu_gyr_temp_kp_f;
-      const WritableStateField<float> imu_gyr_temp_ki_f;
-      const WritableStateField<float> imu_gyr_temp_kd_f;
-      const WritableStateField<float> imu_gyr_temp_desired_f;
+      WritableStateField<float> imu_gyr_temp_kp_f;
+      WritableStateField<float> imu_gyr_temp_ki_f;
+      WritableStateField<float> imu_gyr_temp_kd_f;
+      WritableStateField<float> imu_gyr_temp_desired_f;
 
       std::vector<WritableStateField<bool>> havt_cmd_table_vector_f;
       // end fields necessary for adcs_box controller
@@ -104,7 +104,7 @@ class FieldCreatorTask : public ControlTask<void> {
         imu_gyr_temp_desired_f("adcs_cmd.imu_gyr_temp_desired", Serializer<float>(imu::min_eq_temp, imu::max_eq_temp, 8))
       {
           // Create the fields!
-
+          
           // For MissionManager
           add_writable_field(adcs_cmd_attitude_f);
           add_writable_field(adcs_ang_rate_f);
@@ -119,6 +119,25 @@ class FieldCreatorTask : public ControlTask<void> {
 
           // For propulsion controller
           add_readable_field(prop_mode_f);
+
+          // For ADCS Controller
+          add_writable_field(rwa_mode_f);
+          add_writable_field(rwa_speed_cmd_f);
+          add_writable_field(rwa_torque_cmd_f);
+          add_writable_field(rwa_speed_filter_f);
+          add_writable_field(rwa_ramp_filter_f);
+          add_writable_field(mtr_mode_f);
+          add_writable_field(mtr_cmd_f);
+          add_writable_field(mtr_limit_f);
+          add_writable_field(ssa_voltage_filter_f);
+          add_writable_field(imu_mode_f);
+          add_writable_field(imu_mag_filter_f);
+          add_writable_field(imu_gyr_filter_f);
+          add_writable_field(imu_gyr_temp_filter_f);
+          add_writable_field(imu_gyr_temp_kp_f);
+          add_writable_field(imu_gyr_temp_ki_f);
+          add_writable_field(imu_gyr_temp_kd_f);
+          add_writable_field(imu_gyr_temp_desired_f);
       }
 
       void execute() {

--- a/src/FCCode/FieldCreatorTask.hpp
+++ b/src/FCCode/FieldCreatorTask.hpp
@@ -50,28 +50,6 @@ class FieldCreatorTask : public ControlTask<void> {
       WritableStateField<float> imu_gyr_temp_desired_f;
 
       std::vector<WritableStateField<bool>> havt_cmd_table_vector_f;
-      // end fields necessary for adcs_box controller
-
-      // rwa_mode_f("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
-      // rwa_cmd_f("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
-      // rwa_speed_filter_f("adcs_cmd.rwa_speed_filter", __FILE__, __LINE__);
-      // rwa_ramp_filter_f("adcs_cmd.rwa_ramp_filter", __FILE__, __LINE__);
-
-      // mtr_mode_f("adcs_cmd.mtr_mode", __FILE__, __LINE__);
-      // mtr_cmd_f("adcs_cmd.mtr_cmd", __FILE__, __LINE__);
-      // mtr_limit_f("adcs_cmd.mtr_limit", __FILE__, __LINE__);
-
-      // ssa_mode_f("adcs_cmd.ssa_mode", __FILE__, __LINE__);
-      // ssa_voltage_filter_f("adcs_cmd.ssa_voltage_filter", __FILE__, __LINE__);
-
-      // imu_mode_f("adcs_cmd.imu_mode", __FILE__, __LINE__);
-      // imu_mag_filter_f("adcs_cmd.imu_mag_filter", __FILE__, __LINE__);
-      // imu_gyr_filter_f("adcs_cmd.imu_gyr_filter", __FILE__, __LINE__);
-      // imu_gyr_temp_filter_f("adcs_cmd.imu_gyr_temp_filter", __FILE__, __LINE__);
-      // imu_gyr_temp_kp_f("adcs_cmd.imu_temp_kp", __FILE__, __LINE__);
-      // imu_gyr_temp_ki_f("adcs_cmd.imu_temp_ki", __FILE__, __LINE__);
-      // imu_gyr_temp_kd_f("adcs_cmd.imu_temp_kd", __FILE__, __LINE__);
-      // imu_gyr_temp_desired_f("adcs_cmd.imu_gyr_temp_desired", __FILE__, __LINE__);
 
       FieldCreatorTask(StateFieldRegistry& r) : 
         ControlTask<void>(r),
@@ -138,6 +116,18 @@ class FieldCreatorTask : public ControlTask<void> {
           add_writable_field(imu_gyr_temp_ki_f);
           add_writable_field(imu_gyr_temp_kd_f);
           add_writable_field(imu_gyr_temp_desired_f);
+
+          // reserve memory
+          havt_cmd_table_vector_f.reserve(adcs_havt::Index::_LENGTH);
+          // fill vector of statefields for cmd havt
+          for (unsigned int idx = adcs_havt::Index::IMU_GYR; idx < adcs_havt::Index::_LENGTH; idx++ )
+          {
+            std::memset(buffer, 0, sizeof(buffer));
+            sprintf(buffer,"adcs_cmd.havt_device");
+            sprintf(buffer + strlen(buffer), "%u", idx);
+            havt_table_vector.emplace_back(buffer, havt_bool_sr);
+            add_writable_field(havt_cmd_table_vector_f[idx]);
+          }
       }
 
       void execute() {

--- a/src/FCCode/FieldCreatorTask.hpp
+++ b/src/FCCode/FieldCreatorTask.hpp
@@ -23,51 +23,51 @@ class FieldCreatorTask : public ControlTask<void> {
       ReadableStateField<unsigned char> prop_mode_f;
 
       // begin fields necessary for adcs_box controller
-      const WritableStateField<unsigned char> rwa_mode_fp;
-      const WritableStateField<f_vector_t> rwa_cmd_fp;
-      const WritableStateField<float> rwa_speed_filter_fp;
-      const WritableStateField<float> rwa_ramp_filter_fp;
+      const WritableStateField<unsigned char> rwa_mode_f;
+      const WritableStateField<f_vector_t> rwa_speed_cmd_f;
+      const WritableStateField<f_vector_t> rwa_torque_cmd_f;
+      const WritableStateField<float> rwa_speed_filter_f;
+      const WritableStateField<float> rwa_ramp_filter_f;
 
-      const WritableStateField<unsigned char> mtr_mode_fp;
-      const WritableStateField<f_vector_t> mtr_cmd_fp;
-      const WritableStateField<float> mtr_limit_fp;
+      const WritableStateField<unsigned char> mtr_mode_f;
+      const WritableStateField<f_vector_t> mtr_cmd_f;
+      const WritableStateField<float> mtr_limit_f;
 
-      const WritableStateField<unsigned char> ssa_mode_fp;
-      const WritableStateField<float> ssa_voltage_filter_fp;
+      const WritableStateField<unsigned char> ssa_mode_f;
+      const WritableStateField<float> ssa_voltage_filter_f;
 
-      const WritableStateField<unsigned char> imu_mode_fp;
-      const WritableStateField<float> imu_mag_filter_fp;
-      const WritableStateField<float> imu_gyr_filter_fp;
-      const WritableStateField<float> imu_gyr_temp_filter_fp;
-      const WritableStateField<float> imu_gyr_temp_kp_fp;
-      const WritableStateField<float> imu_gyr_temp_ki_fp;
-      const WritableStateField<float> imu_gyr_temp_kd_fp;
-      const WritableStateField<float> imu_gyr_temp_desired_fp;
+      const WritableStateField<unsigned char> imu_mode_f;
+      const WritableStateField<float> imu_mag_filter_f;
+      const WritableStateField<float> imu_gyr_filter_f;
+      const WritableStateField<float> imu_gyr_temp_filter_f;
+      const WritableStateField<float> imu_gyr_temp_kp_f;
+      const WritableStateField<float> imu_gyr_temp_ki_f;
+      const WritableStateField<float> imu_gyr_temp_kd_f;
+      const WritableStateField<float> imu_gyr_temp_desired_f;
 
-      std::vector<WritableStateField<bool>> havt_cmd_table_vector_fp;
-      }
+      std::vector<WritableStateField<bool>> havt_cmd_table_vector_f;
       // end fields necessary for adcs_box controller
 
-      // rwa_mode_fp = find_writable_field<unsigned char>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
-      // rwa_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
-      // rwa_speed_filter_fp = find_writable_field<float>("adcs_cmd.rwa_speed_filter", __FILE__, __LINE__);
-      // rwa_ramp_filter_fp = find_writable_field<float>("adcs_cmd.rwa_ramp_filter", __FILE__, __LINE__);
+      // rwa_mode_f = find_writable_field<unsigned char>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
+      // rwa_cmd_f = find_writable_field<f_vector_t>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
+      // rwa_speed_filter_f = find_writable_field<float>("adcs_cmd.rwa_speed_filter", __FILE__, __LINE__);
+      // rwa_ramp_filter_f = find_writable_field<float>("adcs_cmd.rwa_ramp_filter", __FILE__, __LINE__);
 
-      // mtr_mode_fp = find_writable_field<unsigned char>("adcs_cmd.mtr_mode", __FILE__, __LINE__);
-      // mtr_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.mtr_cmd", __FILE__, __LINE__);
-      // mtr_limit_fp = find_writable_field<float>("adcs_cmd.mtr_limit", __FILE__, __LINE__);
+      // mtr_mode_f = find_writable_field<unsigned char>("adcs_cmd.mtr_mode", __FILE__, __LINE__);
+      // mtr_cmd_f = find_writable_field<f_vector_t>("adcs_cmd.mtr_cmd", __FILE__, __LINE__);
+      // mtr_limit_f = find_writable_field<float>("adcs_cmd.mtr_limit", __FILE__, __LINE__);
 
-      // ssa_mode_fp = find_writable_field<unsigned char>("adcs_cmd.ssa_mode", __FILE__, __LINE__);
-      // ssa_voltage_filter_fp = find_writable_field<float>("adcs_cmd.ssa_voltage_filter", __FILE__, __LINE__);
+      // ssa_mode_f = find_writable_field<unsigned char>("adcs_cmd.ssa_mode", __FILE__, __LINE__);
+      // ssa_voltage_filter_f = find_writable_field<float>("adcs_cmd.ssa_voltage_filter", __FILE__, __LINE__);
 
-      // imu_mode_fp = find_writable_field<unsigned char>("adcs_cmd.imu_mode", __FILE__, __LINE__);
-      // imu_mag_filter_fp = find_writable_field<float>("adcs_cmd.imu_mag_filter", __FILE__, __LINE__);
-      // imu_gyr_filter_fp = find_writable_field<float>("adcs_cmd.imu_gyr_filter", __FILE__, __LINE__);
-      // imu_gyr_temp_filter_fp = find_writable_field<float>("adcs_cmd.imu_gyr_temp_filter", __FILE__, __LINE__);
-      // imu_gyr_temp_kp_fp = find_writable_field<float>("adcs_cmd.imu_temp_kp", __FILE__, __LINE__);
-      // imu_gyr_temp_ki_fp = find_writable_field<float>("adcs_cmd.imu_temp_ki", __FILE__, __LINE__);
-      // imu_gyr_temp_kd_fp = find_writable_field<float>("adcs_cmd.imu_temp_kd", __FILE__, __LINE__);
-      // imu_gyr_temp_desired_fp = find_writable_field<float>("adcs_cmd.imu_gyr_temp_desired", __FILE__, __LINE__);
+      // imu_mode_f = find_writable_field<unsigned char>("adcs_cmd.imu_mode", __FILE__, __LINE__);
+      // imu_mag_filter_f = find_writable_field<float>("adcs_cmd.imu_mag_filter", __FILE__, __LINE__);
+      // imu_gyr_filter_f = find_writable_field<float>("adcs_cmd.imu_gyr_filter", __FILE__, __LINE__);
+      // imu_gyr_temp_filter_f = find_writable_field<float>("adcs_cmd.imu_gyr_temp_filter", __FILE__, __LINE__);
+      // imu_gyr_temp_kp_f = find_writable_field<float>("adcs_cmd.imu_temp_kp", __FILE__, __LINE__);
+      // imu_gyr_temp_ki_f = find_writable_field<float>("adcs_cmd.imu_temp_ki", __FILE__, __LINE__);
+      // imu_gyr_temp_kd_f = find_writable_field<float>("adcs_cmd.imu_temp_kd", __FILE__, __LINE__);
+      // imu_gyr_temp_desired_f = find_writable_field<float>("adcs_cmd.imu_gyr_temp_desired", __FILE__, __LINE__);
 
       FieldCreatorTask(StateFieldRegistry& r) : 
         ControlTask<void>(r),
@@ -77,7 +77,9 @@ class FieldCreatorTask : public ControlTask<void> {
         pos_f("orbit.pos", Serializer<d_vector_t>(0,100000,100)),
         pos_baseline_f("orbit.baseline_pos", Serializer<d_vector_t>(0,100000,100)),
         docking_config_cmd_f("docksys.config_cmd", Serializer<bool>()),
-        prop_mode_f("prop.mode", Serializer<unsigned char>(1))
+        prop_mode_f("prop.mode", Serializer<unsigned char>(1)),
+        rwa_mode_f("adcs_cmd.rwa_mode", Serializer<unsigned char>(2)),
+        rwa_speed_cmd_f("adcs_cmd.rwa_speed_cmd", Serializer<f_vector_t>(rwa::min_speed_command,))
         
       {
           // Create the fields!

--- a/src/FCCode/FieldCreatorTask.hpp
+++ b/src/FCCode/FieldCreatorTask.hpp
@@ -35,7 +35,6 @@ class FieldCreatorTask : public ControlTask<void> {
       const WritableStateField<f_vector_t> mtr_cmd_f;
       const WritableStateField<float> mtr_limit_f;
 
-      const WritableStateField<unsigned char> ssa_mode_f;
       const WritableStateField<float> ssa_voltage_filter_f;
 
       const WritableStateField<unsigned char> imu_mode_f;
@@ -81,20 +80,17 @@ class FieldCreatorTask : public ControlTask<void> {
         docking_config_cmd_f("docksys.config_cmd", Serializer<bool>()),
         prop_mode_f("prop.mode", Serializer<unsigned char>(1)),
         //eventually you can move all these into ADCSCommander.cpp
-        filter_sr(),
+        filter_sr(0,1,8),
         rwa_mode_f("adcs_cmd.rwa_mode", Serializer<unsigned char>(2)),
         rwa_speed_cmd_f("adcs_cmd.rwa_speed_cmd", Serializer<f_vector_t>(rwa::min_speed_command,rwa::max_speed_command, 16*3)),
         rwa_torque_cmd_f("adcs_cmd.rwa_torque_cmd", Serializer<f_vector_t>(rwa::min_torque, rwa::max_torque, 16*3)),
         rwa_speed_filter_f("adcs_cmd.rwa_speed_filter", filter_sr),
         rwa_ramp_filter_f("adcs_cmd.rwa_ramp_filter", filter_sr),
         mtr_mode_f("adcs_cmd.mtr_mode", Serializer<unsigned char>(2)),
-        mtr_cmd_f("adcs_cmd.mtr_cmd", __FILE__, __LINE__);
-        mtr_limit_f("adcs_cmd.mtr_limit", __FILE__, __LINE__);
-
-        ssa_mode_f("adcs_cmd.ssa_mode", __FILE__, __LINE__);
-        ssa_voltage_filter_f("adcs_cmd.ssa_voltage_filter", __FILE__, __LINE__);
-
-        imu_mode_f("adcs_cmd.imu_mode", __FILE__, __LINE__);
+        mtr_cmd_f("adcs_cmd.mtr_cmd", Serializer<f_vector_t>(mtr::min_moment, mtr::max_moment, 16*3)),
+        mtr_limit_f("adcs_cmd.mtr_limit", Serializer<float>(mtr::min_moment, mtr::max_moment, 16)),
+        ssa_voltage_filter_f("adcs_cmd.ssa_voltage_filter", filter_sr),
+        imu_mode_f("adcs_cmd.imu_mode", Serializer<unsigned char>(4)),
         imu_mag_filter_f("adcs_cmd.imu_mag_filter", __FILE__, __LINE__);
         imu_gyr_filter_f("adcs_cmd.imu_gyr_filter", __FILE__, __LINE__);
         imu_gyr_temp_filter_f("adcs_cmd.imu_gyr_temp_filter", __FILE__, __LINE__);

--- a/src/FCCode/FieldCreatorTask.hpp
+++ b/src/FCCode/FieldCreatorTask.hpp
@@ -22,6 +22,53 @@ class FieldCreatorTask : public ControlTask<void> {
 
       ReadableStateField<unsigned char> prop_mode_f;
 
+      // begin fields necessary for adcs_box controller
+      const WritableStateField<unsigned char> rwa_mode_fp;
+      const WritableStateField<f_vector_t> rwa_cmd_fp;
+      const WritableStateField<float> rwa_speed_filter_fp;
+      const WritableStateField<float> rwa_ramp_filter_fp;
+
+      const WritableStateField<unsigned char> mtr_mode_fp;
+      const WritableStateField<f_vector_t> mtr_cmd_fp;
+      const WritableStateField<float> mtr_limit_fp;
+
+      const WritableStateField<unsigned char> ssa_mode_fp;
+      const WritableStateField<float> ssa_voltage_filter_fp;
+
+      const WritableStateField<unsigned char> imu_mode_fp;
+      const WritableStateField<float> imu_mag_filter_fp;
+      const WritableStateField<float> imu_gyr_filter_fp;
+      const WritableStateField<float> imu_gyr_temp_filter_fp;
+      const WritableStateField<float> imu_gyr_temp_kp_fp;
+      const WritableStateField<float> imu_gyr_temp_ki_fp;
+      const WritableStateField<float> imu_gyr_temp_kd_fp;
+      const WritableStateField<float> imu_gyr_temp_desired_fp;
+
+      std::vector<WritableStateField<bool>> havt_cmd_table_vector_fp;
+      }
+      // end fields necessary for adcs_box controller
+
+      // rwa_mode_fp = find_writable_field<unsigned char>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
+      // rwa_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
+      // rwa_speed_filter_fp = find_writable_field<float>("adcs_cmd.rwa_speed_filter", __FILE__, __LINE__);
+      // rwa_ramp_filter_fp = find_writable_field<float>("adcs_cmd.rwa_ramp_filter", __FILE__, __LINE__);
+
+      // mtr_mode_fp = find_writable_field<unsigned char>("adcs_cmd.mtr_mode", __FILE__, __LINE__);
+      // mtr_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.mtr_cmd", __FILE__, __LINE__);
+      // mtr_limit_fp = find_writable_field<float>("adcs_cmd.mtr_limit", __FILE__, __LINE__);
+
+      // ssa_mode_fp = find_writable_field<unsigned char>("adcs_cmd.ssa_mode", __FILE__, __LINE__);
+      // ssa_voltage_filter_fp = find_writable_field<float>("adcs_cmd.ssa_voltage_filter", __FILE__, __LINE__);
+
+      // imu_mode_fp = find_writable_field<unsigned char>("adcs_cmd.imu_mode", __FILE__, __LINE__);
+      // imu_mag_filter_fp = find_writable_field<float>("adcs_cmd.imu_mag_filter", __FILE__, __LINE__);
+      // imu_gyr_filter_fp = find_writable_field<float>("adcs_cmd.imu_gyr_filter", __FILE__, __LINE__);
+      // imu_gyr_temp_filter_fp = find_writable_field<float>("adcs_cmd.imu_gyr_temp_filter", __FILE__, __LINE__);
+      // imu_gyr_temp_kp_fp = find_writable_field<float>("adcs_cmd.imu_temp_kp", __FILE__, __LINE__);
+      // imu_gyr_temp_ki_fp = find_writable_field<float>("adcs_cmd.imu_temp_ki", __FILE__, __LINE__);
+      // imu_gyr_temp_kd_fp = find_writable_field<float>("adcs_cmd.imu_temp_kd", __FILE__, __LINE__);
+      // imu_gyr_temp_desired_fp = find_writable_field<float>("adcs_cmd.imu_gyr_temp_desired", __FILE__, __LINE__);
+
       FieldCreatorTask(StateFieldRegistry& r) : 
         ControlTask<void>(r),
         adcs_cmd_attitude_f("adcs.cmd_attitude", Serializer<f_quat_t>()),
@@ -31,6 +78,7 @@ class FieldCreatorTask : public ControlTask<void> {
         pos_baseline_f("orbit.baseline_pos", Serializer<d_vector_t>(0,100000,100)),
         docking_config_cmd_f("docksys.config_cmd", Serializer<bool>()),
         prop_mode_f("prop.mode", Serializer<unsigned char>(1))
+        
       {
           // Create the fields!
 

--- a/src/FCCode/FieldCreatorTask.hpp
+++ b/src/FCCode/FieldCreatorTask.hpp
@@ -91,15 +91,13 @@ class FieldCreatorTask : public ControlTask<void> {
         mtr_limit_f("adcs_cmd.mtr_limit", Serializer<float>(mtr::min_moment, mtr::max_moment, 16)),
         ssa_voltage_filter_f("adcs_cmd.ssa_voltage_filter", filter_sr),
         imu_mode_f("adcs_cmd.imu_mode", Serializer<unsigned char>(4)),
-        imu_mag_filter_f("adcs_cmd.imu_mag_filter", __FILE__, __LINE__);
-        imu_gyr_filter_f("adcs_cmd.imu_gyr_filter", __FILE__, __LINE__);
-        imu_gyr_temp_filter_f("adcs_cmd.imu_gyr_temp_filter", __FILE__, __LINE__);
-        imu_gyr_temp_kp_f("adcs_cmd.imu_temp_kp", __FILE__, __LINE__);
-        imu_gyr_temp_ki_f("adcs_cmd.imu_temp_ki", __FILE__, __LINE__);
-        imu_gyr_temp_kd_f("adcs_cmd.imu_temp_kd", __FILE__, __LINE__);
-        imu_gyr_temp_desired_f("adcs_cmd.imu_gyr_temp_desired", __FILE__, __LINE__);
-
-        
+        imu_mag_filter_f("adcs_cmd.imu_mag_filter", filter_sr),
+        imu_gyr_filter_f("adcs_cmd.imu_gyr_filter", filter_sr),
+        imu_gyr_temp_filter_f("adcs_cmd.imu_gyr_temp_filter", filter_sr),
+        imu_gyr_temp_kp_f("adcs_cmd.imu_temp_kp", filter_sr),
+        imu_gyr_temp_ki_f("adcs_cmd.imu_temp_ki", filter_sr),
+        imu_gyr_temp_kd_f("adcs_cmd.imu_temp_kd", filter_sr),
+        imu_gyr_temp_desired_f("adcs_cmd.imu_gyr_temp_desired", filter_sr)
       {
           // Create the fields!
 

--- a/src/FCCode/FieldCreatorTask.hpp
+++ b/src/FCCode/FieldCreatorTask.hpp
@@ -23,6 +23,8 @@ class FieldCreatorTask : public ControlTask<void> {
       ReadableStateField<unsigned char> prop_mode_f;
 
       // begin fields necessary for adcs_box controller
+      const Serializer<float> filter_sr;
+
       const WritableStateField<unsigned char> rwa_mode_f;
       const WritableStateField<f_vector_t> rwa_speed_cmd_f;
       const WritableStateField<f_vector_t> rwa_torque_cmd_f;
@@ -48,26 +50,26 @@ class FieldCreatorTask : public ControlTask<void> {
       std::vector<WritableStateField<bool>> havt_cmd_table_vector_f;
       // end fields necessary for adcs_box controller
 
-      // rwa_mode_f = find_writable_field<unsigned char>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
-      // rwa_cmd_f = find_writable_field<f_vector_t>("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
-      // rwa_speed_filter_f = find_writable_field<float>("adcs_cmd.rwa_speed_filter", __FILE__, __LINE__);
-      // rwa_ramp_filter_f = find_writable_field<float>("adcs_cmd.rwa_ramp_filter", __FILE__, __LINE__);
+      // rwa_mode_f("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
+      // rwa_cmd_f("adcs_cmd.rwa_cmd", __FILE__, __LINE__);
+      // rwa_speed_filter_f("adcs_cmd.rwa_speed_filter", __FILE__, __LINE__);
+      // rwa_ramp_filter_f("adcs_cmd.rwa_ramp_filter", __FILE__, __LINE__);
 
-      // mtr_mode_f = find_writable_field<unsigned char>("adcs_cmd.mtr_mode", __FILE__, __LINE__);
-      // mtr_cmd_f = find_writable_field<f_vector_t>("adcs_cmd.mtr_cmd", __FILE__, __LINE__);
-      // mtr_limit_f = find_writable_field<float>("adcs_cmd.mtr_limit", __FILE__, __LINE__);
+      // mtr_mode_f("adcs_cmd.mtr_mode", __FILE__, __LINE__);
+      // mtr_cmd_f("adcs_cmd.mtr_cmd", __FILE__, __LINE__);
+      // mtr_limit_f("adcs_cmd.mtr_limit", __FILE__, __LINE__);
 
-      // ssa_mode_f = find_writable_field<unsigned char>("adcs_cmd.ssa_mode", __FILE__, __LINE__);
-      // ssa_voltage_filter_f = find_writable_field<float>("adcs_cmd.ssa_voltage_filter", __FILE__, __LINE__);
+      // ssa_mode_f("adcs_cmd.ssa_mode", __FILE__, __LINE__);
+      // ssa_voltage_filter_f("adcs_cmd.ssa_voltage_filter", __FILE__, __LINE__);
 
-      // imu_mode_f = find_writable_field<unsigned char>("adcs_cmd.imu_mode", __FILE__, __LINE__);
-      // imu_mag_filter_f = find_writable_field<float>("adcs_cmd.imu_mag_filter", __FILE__, __LINE__);
-      // imu_gyr_filter_f = find_writable_field<float>("adcs_cmd.imu_gyr_filter", __FILE__, __LINE__);
-      // imu_gyr_temp_filter_f = find_writable_field<float>("adcs_cmd.imu_gyr_temp_filter", __FILE__, __LINE__);
-      // imu_gyr_temp_kp_f = find_writable_field<float>("adcs_cmd.imu_temp_kp", __FILE__, __LINE__);
-      // imu_gyr_temp_ki_f = find_writable_field<float>("adcs_cmd.imu_temp_ki", __FILE__, __LINE__);
-      // imu_gyr_temp_kd_f = find_writable_field<float>("adcs_cmd.imu_temp_kd", __FILE__, __LINE__);
-      // imu_gyr_temp_desired_f = find_writable_field<float>("adcs_cmd.imu_gyr_temp_desired", __FILE__, __LINE__);
+      // imu_mode_f("adcs_cmd.imu_mode", __FILE__, __LINE__);
+      // imu_mag_filter_f("adcs_cmd.imu_mag_filter", __FILE__, __LINE__);
+      // imu_gyr_filter_f("adcs_cmd.imu_gyr_filter", __FILE__, __LINE__);
+      // imu_gyr_temp_filter_f("adcs_cmd.imu_gyr_temp_filter", __FILE__, __LINE__);
+      // imu_gyr_temp_kp_f("adcs_cmd.imu_temp_kp", __FILE__, __LINE__);
+      // imu_gyr_temp_ki_f("adcs_cmd.imu_temp_ki", __FILE__, __LINE__);
+      // imu_gyr_temp_kd_f("adcs_cmd.imu_temp_kd", __FILE__, __LINE__);
+      // imu_gyr_temp_desired_f("adcs_cmd.imu_gyr_temp_desired", __FILE__, __LINE__);
 
       FieldCreatorTask(StateFieldRegistry& r) : 
         ControlTask<void>(r),
@@ -78,8 +80,29 @@ class FieldCreatorTask : public ControlTask<void> {
         pos_baseline_f("orbit.baseline_pos", Serializer<d_vector_t>(0,100000,100)),
         docking_config_cmd_f("docksys.config_cmd", Serializer<bool>()),
         prop_mode_f("prop.mode", Serializer<unsigned char>(1)),
+        //eventually you can move all these into ADCSCommander.cpp
+        filter_sr(),
         rwa_mode_f("adcs_cmd.rwa_mode", Serializer<unsigned char>(2)),
-        rwa_speed_cmd_f("adcs_cmd.rwa_speed_cmd", Serializer<f_vector_t>(rwa::min_speed_command,))
+        rwa_speed_cmd_f("adcs_cmd.rwa_speed_cmd", Serializer<f_vector_t>(rwa::min_speed_command,rwa::max_speed_command, 16*3)),
+        rwa_torque_cmd_f("adcs_cmd.rwa_torque_cmd", Serializer<f_vector_t>(rwa::min_torque, rwa::max_torque, 16*3)),
+        rwa_speed_filter_f("adcs_cmd.rwa_speed_filter", filter_sr),
+        rwa_ramp_filter_f("adcs_cmd.rwa_ramp_filter", filter_sr),
+        mtr_mode_f("adcs_cmd.mtr_mode", Serializer<unsigned char>(2)),
+        mtr_cmd_f("adcs_cmd.mtr_cmd", __FILE__, __LINE__);
+        mtr_limit_f("adcs_cmd.mtr_limit", __FILE__, __LINE__);
+
+        ssa_mode_f("adcs_cmd.ssa_mode", __FILE__, __LINE__);
+        ssa_voltage_filter_f("adcs_cmd.ssa_voltage_filter", __FILE__, __LINE__);
+
+        imu_mode_f("adcs_cmd.imu_mode", __FILE__, __LINE__);
+        imu_mag_filter_f("adcs_cmd.imu_mag_filter", __FILE__, __LINE__);
+        imu_gyr_filter_f("adcs_cmd.imu_gyr_filter", __FILE__, __LINE__);
+        imu_gyr_temp_filter_f("adcs_cmd.imu_gyr_temp_filter", __FILE__, __LINE__);
+        imu_gyr_temp_kp_f("adcs_cmd.imu_temp_kp", __FILE__, __LINE__);
+        imu_gyr_temp_ki_f("adcs_cmd.imu_temp_ki", __FILE__, __LINE__);
+        imu_gyr_temp_kd_f("adcs_cmd.imu_temp_kd", __FILE__, __LINE__);
+        imu_gyr_temp_desired_f("adcs_cmd.imu_gyr_temp_desired", __FILE__, __LINE__);
+
         
       {
           // Create the fields!

--- a/src/FCCode/FieldCreatorTask.hpp
+++ b/src/FCCode/FieldCreatorTask.hpp
@@ -41,6 +41,9 @@ class FieldCreatorTask : public ControlTask<void> {
       const WritableStateField<float> imu_mag_filter_f;
       const WritableStateField<float> imu_gyr_filter_f;
       const WritableStateField<float> imu_gyr_temp_filter_f;
+
+      const Serializer<float> k_sr;
+
       const WritableStateField<float> imu_gyr_temp_kp_f;
       const WritableStateField<float> imu_gyr_temp_ki_f;
       const WritableStateField<float> imu_gyr_temp_kd_f;
@@ -94,10 +97,11 @@ class FieldCreatorTask : public ControlTask<void> {
         imu_mag_filter_f("adcs_cmd.imu_mag_filter", filter_sr),
         imu_gyr_filter_f("adcs_cmd.imu_gyr_filter", filter_sr),
         imu_gyr_temp_filter_f("adcs_cmd.imu_gyr_temp_filter", filter_sr),
-        imu_gyr_temp_kp_f("adcs_cmd.imu_temp_kp", filter_sr),
-        imu_gyr_temp_ki_f("adcs_cmd.imu_temp_ki", filter_sr),
-        imu_gyr_temp_kd_f("adcs_cmd.imu_temp_kd", filter_sr),
-        imu_gyr_temp_desired_f("adcs_cmd.imu_gyr_temp_desired", filter_sr)
+        k_sr(std::numeric_limits<float>::min(), std::numeric_limits<float>::max(),16),
+        imu_gyr_temp_kp_f("adcs_cmd.imu_temp_kp", k_sr),
+        imu_gyr_temp_ki_f("adcs_cmd.imu_temp_ki", k_sr),
+        imu_gyr_temp_kd_f("adcs_cmd.imu_temp_kd", k_sr),
+        imu_gyr_temp_desired_f("adcs_cmd.imu_gyr_temp_desired", Serializer<float>(imu::min_eq_temp, imu::max_eq_temp, 8))
       {
           // Create the fields!
 

--- a/src/FCCode/MainControlLoop.cpp
+++ b/src/FCCode/MainControlLoop.cpp
@@ -79,6 +79,7 @@ void MainControlLoop::execute() {
 
     piksi_control_task.execute_on_time();
     gomspace_controller.execute_on_time();
+    adcs_monitor.execute_on_time();
     attitude_estimator.execute_on_time();
     mission_manager.execute_on_time();
     attitude_computer.execute_on_time();

--- a/src/FCCode/MainControlLoop.cpp
+++ b/src/FCCode/MainControlLoop.cpp
@@ -39,7 +39,8 @@ MainControlLoop::MainControlLoop(StateFieldRegistry& registry,
       eeprom_controller(registry, eeprom_controller_offset, statefields),
       memory_use_f("sys.memory_use", Serializer<unsigned int>(300000)),
       mission_manager(registry, mission_manager_offset), // This item is initialized near-last so it has access to all state fields
-      attitude_computer(registry, attitude_computer_offset) // This item needs "adcs.state" from mission manager.
+      attitude_computer(registry, attitude_computer_offset), // This item needs "adcs.state" from mission manager.
+      adcs_box_controller(registry, adcs_box_controller_offset, adcs)
 {
     docking_controller.init();
 
@@ -81,6 +82,7 @@ void MainControlLoop::execute() {
     attitude_estimator.execute_on_time();
     mission_manager.execute_on_time();
     attitude_computer.execute_on_time();
+    adcs_box_controller.execute_on_time();
     downlink_producer.execute_on_time();
     quake_manager.execute_on_time();
     docking_controller.execute_on_time();

--- a/src/FCCode/MainControlLoop.hpp
+++ b/src/FCCode/MainControlLoop.hpp
@@ -8,6 +8,7 @@
 #include "ClockManager.hpp"
 #include "PiksiControlTask.hpp"
 #include "ADCSBoxMonitor.hpp"
+#include "ADCSBoxController.hpp"
 #include "AttitudeEstimator.hpp"
 #include "AttitudeComputer.hpp"
 #include "GomspaceController.hpp"
@@ -63,8 +64,9 @@ class MainControlLoop : public ControlTask<void> {
         static constexpr unsigned int uplink_consumer_offset     = 111500;
         static constexpr unsigned int mission_manager_offset     = 111600;
         static constexpr unsigned int attitude_computer_offset   = 111700;
+        static constexpr unsigned int adcs_box_controller_offset = 147400;
         static constexpr unsigned int docking_controller_offset  = 152400;
-        static constexpr unsigned int downlink_producer_offset   = 153400;
+        static constexpr unsigned int downlink_producer_offset   = 153400; // excel says 152900
         static constexpr unsigned int quake_manager_offset       = 153500;
         static constexpr unsigned int eeprom_controller_offset   = 153500;  // fix this later
     #else
@@ -76,10 +78,11 @@ class MainControlLoop : public ControlTask<void> {
         static constexpr unsigned int uplink_consumer_offset     =  61500;
         static constexpr unsigned int mission_manager_offset     =  61600;
         static constexpr unsigned int attitude_computer_offset   =  61700;
-        static constexpr unsigned int docking_controller_offset  = 103400;
-        static constexpr unsigned int downlink_producer_offset   = 104400;
+        static constexpr unsigned int adcs_box_controller_offset =  97400;
+        static constexpr unsigned int docking_controller_offset  = 103400; // excel says 102400
+        static constexpr unsigned int downlink_producer_offset   = 104400; // excel says 102900
         static constexpr unsigned int quake_manager_offset       = 104500;
-        static constexpr unsigned int eeprom_controller_offset   = 153500;
+        static constexpr unsigned int eeprom_controller_offset   = 153500; // too high?
     #endif
 
     /**
@@ -90,6 +93,8 @@ class MainControlLoop : public ControlTask<void> {
     MissionManager mission_manager;
 
     AttitudeComputer attitude_computer;
+
+    ADCSBoxController adcs_box_controller; // needs adcs.state from MissionManager
 
    public:
     /*

--- a/src/FCCode/MainControlLoop.hpp
+++ b/src/FCCode/MainControlLoop.hpp
@@ -92,7 +92,7 @@ class MainControlLoop : public ControlTask<void> {
 
     MissionManager mission_manager;
 
-    AttitudeComputer attitude_computer;
+    AttitudeComputer attitude_computer; // needs adcs.state from MissionManager
 
     ADCSBoxController adcs_box_controller; // needs adcs.state from MissionManager
 


### PR DESCRIPTION
This PR contains the ADCSBoxController Control Task. Its main purpose is to use the ADCS driver and execute low-level hardware calls. Its inputs mostly come from the yet to be created ADCSCommander.

It also applies the havt_cmd table, and restarts SSA vector calculation.