### PR TITLE
Migrated ADCS Device Drivers into the Source Folder

### DIFF
--- a/configs/adcs.ini
+++ b/configs/adcs.ini
@@ -11,12 +11,12 @@
 
 [adcs_teensy32]
 extends = teensy32
-lib_extra_dirs = lib/adcs
+lib_deps = 
 lib_ldf_mode = chain+
 
 [adcs_teensy35]
 extends = teensy35
-lib_extra_dirs = lib/adcs
+lib_deps =
 lib_ldf_mode = chain+
 
 [adcs_teensy35_flight]

--- a/configs/adcs.ini
+++ b/configs/adcs.ini
@@ -21,7 +21,7 @@ lib_ldf_mode = chain+
 
 [adcs_teensy35_flight]
 extends = adcs_teensy35
-src_filter = +<adcs/*.cpp>
+src_filter = +<adcs/*.cpp> +<adcs/dev/*.cpp>
 
 ; adcs_teensy35_flight_leader
 ;
@@ -104,6 +104,9 @@ build_flags =
   ${adcs_teensy35_script.build_flags}
   -DIMU_DEBUG
 src_filter =
+  +<adcs/dev/LIS2MDLTR.cpp>
+  +<adcs/dev/LSM6DSM.cpp>
+  +<adcs/dev/MMC34160PJ.cpp>
   +<adcs/imu.cpp>
   +<adcs/imu_calibration.cpp>
   +<adcs/scripts/imu_test.cpp>
@@ -117,6 +120,7 @@ build_flags =
   ${adcs_teensy35_script.build_flags}
   -DMTR_DEBUG
 src_filter =
+  +<adcs/dev/Magnetorquer.cpp>
   +<adcs/mtr.cpp>
   +<adcs/scripts/mtr_test.cpp>
 
@@ -129,6 +133,9 @@ build_flags =
   ${adcs_teensy35_script.build_flags}
   -DRWA_DEBUG
 src_filter =
+  +<adcs/dev/AD5254.cpp>
+  +<adcs/dev/ADS1015.cpp>
+  +<adcs/dev/MaxonEC45.cpp>
   +<adcs/rwa.cpp>
   +<adcs/scripts/rwa_test.cpp>
 
@@ -141,8 +148,9 @@ build_flags =
   ${adcs_teensy35_script.build_flags}
   -DSSA_DEBUG
 src_filter =
-  +<adcs/ssa.cpp>
+  +<adcs/dev/ADS1015.cpp>
   +<adcs/scripts/ssa_test.cpp>
+  +<adcs/ssa.cpp>
 
 ; adcs_teensy35_script_state_test
 ;
@@ -153,9 +161,9 @@ build_flags =
   ${adcs_teensy35_script.build_flags}
   -DUMB_DEBUG
 src_filter =
+  +<adcs/scripts/state_test.cpp>
   +<adcs/state.cpp>
   +<adcs/state_controller.cpp>
-  +<adcs/scripts/state_test.cpp>
 
 ; adcs_teensy32_script_state_test
 ;
@@ -166,9 +174,9 @@ build_flags =
   ${adcs_teensy32_script.build_flags}
   -DUMB_DEBUG
 src_filter =
+  +<adcs/scripts/state_test.cpp>
   +<adcs/state.cpp>
   +<adcs/state_controller.cpp>
-  +<adcs/scripts/state_test.cpp>
 
 ; adcs_teensy35_script_ADS1015_test
 ;
@@ -176,6 +184,7 @@ src_filter =
 [env:adcs_teensy35_script_ADS1015_test]
 extends = adcs_teensy35_script
 src_filter =
+  +<adcs/dev/ADS1015.cpp>
   +<adcs/scripts/ADS1015_test.cpp>
 
 ; adcs_teensy35_script_LSM6DSM_test
@@ -184,6 +193,7 @@ src_filter =
 [env:adcs_teensy35_script_LSM6DSM_test]
 extends = adcs_teensy35_script
 src_filter =
+  +<adcs/dev/LSM6DSM.cpp>
   +<adcs/scripts/LSM6DSM_test.cpp>
 
 ; adcs_teensy35_script_MMC34160PJ_test
@@ -192,4 +202,5 @@ src_filter =
 [env:adcs_teensy35_script_MMC34160PJ_test]
 extends = adcs_teensy35_script
 src_filter =
+  +<adcs/dev/MMC34160PJ.cpp>
   +<adcs/scripts/MMC34160PJ_test.cpp>

--- a/configs/hardware_test_envs.ini
+++ b/configs/hardware_test_envs.ini
@@ -9,7 +9,7 @@ lib_deps =
   CommonSoftware/
 build_flags = -std=c++14 -Werror -Wall -D UNITY_INCLUDE_DOUBLE -O3 -DLIN_RANDOM_SEED=358264 -D PAN_LEADER -D SERIAL3_RX_BUFFER_SIZE=512
 lib_extra_dirs = lib/fsw
-src_filter = +<fsw/teensy_stub.cpp>
+src_filter = +<fsw/targets/teensy_stub.cpp>
 upload_protocol = teensy-cli
 test_build_project_src = true
 
@@ -62,13 +62,13 @@ test_filter = test_piksi
 [env:fsw_teensy35_test_adcs]
 board = teensy35
 extends = fsw_hardware_common
-src_filter = +<fsw/adcs_test.cpp>
+src_filter = +<fsw/targets/adcs_test.cpp>
 test_ignore = *
 
 [env:fsw_teensy36_test_adcs]
 board = teensy36
 extends = fsw_hardware_common
-src_filter = +<fsw/adcs_test.cpp>
+src_filter = +<fsw/targets/adcs_test.cpp>
 test_ignore = *
 
 [env:fsw_test_adcs_havt]

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@
 
 [platformio]
 lib_dir = lib/common/
-extra_configs = configs/*
+extra_configs = configs/*.ini
 
 [all]
 build_flags =

--- a/src/adcs/constants.hpp
+++ b/src/adcs/constants.hpp
@@ -1,0 +1,202 @@
+//
+// src/adcs/constants.hpp
+// FlightSoftware
+//
+// Contributors:
+//   Kyle Krol  kpk63@cornell.edu
+//
+// Pathfinder for Autonomous Navigation
+// Space Systems Design Studio
+// Cornell Univeristy
+//
+
+// TODO
+// Calibrate gyroscope min and max temperature
+
+#ifndef SRC_ADCS_ADCS_CONSTANTS_HPP_
+#define SRC_ADCS_ADCS_CONSTANTS_HPP_
+
+namespace adcs {
+
+/** \enum Endianness
+ *  Sets the endianness of the I2C transmissions. **/
+enum Endianness : unsigned char {
+  /** Sets the I2C messages to little-endian interpretation. **/
+  LITTLE = 0,
+  /** Sets the I2C messages to big-endian interpretation. **/
+  BIG = 1
+};
+
+/** \enum ADCSMode
+ *  Enumeration of ADCS modes. **/
+enum ADCSMode : unsigned char {
+  /** Only passive sensor measurements are taken. **/
+  ADCS_PASSIVE = 0,
+  /** All ADCS peripherials are enabled. **/
+  ADCS_ACTIVE = 1
+};
+
+/** \enum IMUMode
+ *  Outlines all modes of the IMU assembly. */
+enum IMUMode : unsigned char {
+  /** ADCS attempts to read the first magnetometer. */
+  MAG1 = 0,
+  /** ADCS attempts to read the second magnetometer. */
+  MAG2 = 1,
+  /** ADCS calibrates the first magnetometer and then reads in from then on. */
+  MAG1_CALIBRATE = 2,
+  /** ADCS calibrates the second magnetometer and then reads in from then on. */
+  MAG2_CALIBRATE = 3
+};
+
+/** \enum MTRMode
+ *  Outlines all modes of the magnetic torque rods. */
+enum MTRMode : unsigned char {
+  /** Disables the magnetic torque rods. */
+  MTR_DISABLED = 0,
+  /** Places the magnetic torque rods under normal operation. */
+  MTR_ENABLED = 1
+};
+
+/** \enum RWAMode
+ *  Outlines all modes of the reaction wheels. **/
+enum RWAMode : unsigned char {
+  /** Disables the reaction wheels. */
+  RWA_DISABLED = 0,
+  /** Speed controlled mode. **/
+  RWA_SPEED_CTRL = 1,
+  /** Acceleration controlled mode. **/
+  RWA_ACCEL_CTRL = 2
+};
+
+/** \enum SSAMode
+ *  Outlines all modes of the sun sensors. **/
+enum SSAMode : unsigned char {
+  /** Conversion may have failed and the sun vector is not realiable. **/
+  SSA_FAILURE = 0,
+  /** Conversion to sun vector in progress. **/
+  SSA_IN_PROGRESS = 1,
+  /** Succesful conversion has been completed. **/
+  SSA_COMPLETE = 2
+};
+
+/** \enum CMDFlag
+ *  Outlines all possible actuation command modes. */
+enum CMDFlag : unsigned char {
+  /** No new actuation command is present. */
+  OUTDATED = 0,
+  /** A new actuation command is present. */
+  UPDATED = 1
+};
+
+namespace imu {
+
+/** Highest temperature in degrees celcius the gyroscope's equilibrium
+ *  temperature can be set to. */
+constexpr static float max_eq_temp = 85.0f;
+/** Lowest termperature in degrees celcius the gyroscope's equilibrium
+ * temperature can be set to. */
+constexpr static float min_eq_temp = -40.0f;
+/** Maximum temperature reading in degress celcius that can be output by the
+ *  gyroscope. */
+#if defined(PAN_LEADER)
+constexpr static float max_rd_temp = 25.0f + 128.0f;  // TODO : Calibrate
+#elif defined(PAN_FOLLOWER)
+constexpr static float max_rd_temp = 25.0f + 128.0f;  // TODO : Calibrate
+#else
+static_assert(false, "Must define PAN_LEADER or PAN_FOLLOWER");
+#endif
+/** Minimum temperature reading in degrees celcius that can be output by the
+ *  gyroscope. */
+#if defined(PAN_LEADER)
+constexpr static float min_rd_temp = 25.0f - 128.0f;  // TODO : Calibrate
+#elif defined(PAN_FOLLOWER)
+constexpr static float min_rd_temp = 25.0f - 128.0f;  // TODO : Calibrate
+#else
+static_assert(false, "Must define PAN_LEADER or PAN_FOLLOWER");
+#endif
+/** Maximum angular rate in radians per second that can be read from the
+ *  gyroscope. */
+constexpr static float max_rd_omega = 125.0f * 0.03490658504f; // 2 * pi / 180
+/** Minimum angular rate in radians per second that can be read from the
+ *  gyroscope. */
+constexpr static float min_rd_omega = -max_rd_omega;
+
+/** Maximum magnetic field reading in Tesla that can be read from the first
+ *  magnetometer. */
+constexpr static float max_mag1_rd_mag = 0.0016f; // TODO : Check this
+/** Minimum magnetic field reading in Tesla that can be read from the first
+ *  magnetometer. */
+constexpr static float min_mag1_rd_mag = -max_mag1_rd_mag;
+
+/** Maximum magnetic field reading in Tesla that can be read from the second
+ *  magnetometer. */
+constexpr static float max_mag2_rd_mag = 0.0016f; // TODO : Check this
+/** Minimum magnetic field reading in Tesla that can be read from the second
+ *  magnetometer. */
+constexpr static float min_mag2_rd_mag = -max_mag2_rd_mag;
+
+/** Maximum magnetic field reading in Tesla that can be read per component. */
+constexpr static float max_rd_mag =
+    (max_mag1_rd_mag > max_mag2_rd_mag ? max_mag1_rd_mag : max_mag2_rd_mag);
+/** Minimum magnetic field reading in Tesla that can be read per component. */
+constexpr static float min_rd_mag = -max_rd_mag;
+
+}  // namespace imu
+
+namespace mtr {
+
+/** Maximum moment available from the magnetic torque rods. */
+constexpr static float max_moment = 0.113337f / 2.0f; // Assumes one mtr not two
+/** Minimum moment available from the magnetic toque rods. */
+constexpr static float min_moment = -max_moment;
+
+}  // namespace mtr
+
+namespace rwa {
+
+/* Maximum torque available from the reaction wheels. Note the maximum ramp maps
+ * to 310.1852 rad s^-2 and the moment of inertia is 1.35e-5 kg m^2. */
+
+/** Moment of interia of a reaction wheel. */
+constexpr static float moment_of_inertia = 0.0000135f;
+/** Maximum torque available from the reaction wheels. */
+constexpr static float max_torque = 310.1852f * moment_of_inertia;
+/** Minimum torque available from the reaction wheels. */
+constexpr static float min_torque = -max_torque;
+/** Maximum speed read from the reaction wheels. */
+constexpr static float max_speed_read = 1047.20f;
+/** Minimum speed read from the reaction wheels. */
+constexpr static float min_speed_read = -max_speed_read;
+
+/** Maximum speed read from the reaction wheels. */
+constexpr static float max_speed_command = 680.678f;
+/** Minimum speed command to the reaction wheels. */
+constexpr static float min_speed_command = -max_speed_command;
+
+}  // namespace rwa
+
+namespace ssa {
+
+/** Minimum voltage that can be read from a sun sensor. */
+constexpr static float min_voltage_rd = 0.0f;
+/** Maximum voltage that can be read from a sun sensor. */
+constexpr static float max_voltage_rd = 3.3f;
+/** Minimum SSA algorithm voltage threshold. */
+constexpr static float min_voltage_thresh = min_voltage_rd;
+/** Maximum SSA algorithm voltage threshold. */
+constexpr static float max_voltage_thresh = max_voltage_rd;
+/** Number of sun sensors */
+constexpr static unsigned char num_sun_sensors = 20;
+
+}  // namespace ssa
+
+namespace havt {
+
+/** Maximum number of devices in the HAVT table. Leave as 32, not meant to be adjusted */
+constexpr static unsigned char max_devices = 32;
+
+} // namespace havt
+}  // namespace adcs
+
+#endif

--- a/src/adcs/dev/AD5254.cpp
+++ b/src/adcs/dev/AD5254.cpp
@@ -1,6 +1,6 @@
 //
-// lib/AD5254/AD5254.cpp
-// ADCS
+// src/adcs/dev/AD5254.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Nathan Zimmerberg  nhz2@cornell.edu
@@ -13,12 +13,15 @@
 
 #include "AD5254.hpp"
 
+namespace adcs {
+namespace dev {
+
 void AD5254::setup(i2c_t3 *wire, uint8_t addr, unsigned long timeout) {
-  this->dev::I2CDevice::setup(wire, addr, timeout);
+  this->I2CDevice::setup(wire, addr, timeout);
 }
 
 bool AD5254::reset() {
-  this->dev::I2CDevice::reset();
+  this->I2CDevice::reset();
   this->set_rdac0(AD5254_RDAC_DEFAULT);
   this->set_rdac1(AD5254_RDAC_DEFAULT);
   this->set_rdac2(AD5254_RDAC_DEFAULT);
@@ -53,3 +56,5 @@ bool AD5254::write_rdac() {
   this->start_write_rdac();
   return this->end_write_rdac();
 }
+}  // namespace dev
+}  // namespace adcs

--- a/src/adcs/dev/AD5254.hpp
+++ b/src/adcs/dev/AD5254.hpp
@@ -1,6 +1,6 @@
 //
-// lib/AD5254/AD5254.hpp
-// ADCS
+// src/adcs/dev/AD5254.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Nathan Zimmerberg  nhz2@cornell.edu
@@ -11,13 +11,10 @@
 // Cornell Univeristy
 //
 
-#ifndef ADCS_LIB_AD5254_AD5254_HPP_
-#define ADCS_LIB_AD5254_AD5254_HPP_
+#ifndef SRC_ADCS_DEV_AD5254_HPP_
+#define SRC_ADCS_DEV_AD5254_HPP_
 
-#include <I2CDevice.hpp>
-
-/** @addtogroup lib
- *  @{ */
+#include "I2CDevice.hpp"
 
 #ifndef AD5254_RDAC_DEFAULT
 /** Specifies the defaul rdac value for the AD5254 potentiometer. Can be changed
@@ -25,9 +22,12 @@
 #define AD5254_RDAC_DEFAULT 0x00
 #endif
 
+namespace adcs {
+namespace dev {
+
 /** @class AD5254
  *  Simple driver to adjust potentiometer resistances of the AD5254. **/
-class AD5254 : public dev::I2CDevice {
+class AD5254 : public I2CDevice {
  public:
   /** @enum ADDR
    *  Possible addresses for the potentiometer. **/
@@ -76,7 +76,7 @@ class AD5254 : public dev::I2CDevice {
   /** Backing array for rdac settings. **/
   uint8_t rdac[4];
 };
-
-/** @} */
+}  // namespace dev
+}  // namespace adcs
 
 #endif

--- a/src/adcs/dev/ADS1015.cpp
+++ b/src/adcs/dev/ADS1015.cpp
@@ -12,15 +12,18 @@
 
 #include "ADS1015.hpp"
 
+namespace adcs {
+namespace dev {
+
 void ADS1015::setup(i2c_t3 *wire, uint8_t addr, unsigned int alert_pin, unsigned long timeout) {
-  this->dev::I2CDevice::setup(wire, addr, timeout);
+  this->I2CDevice::setup(wire, addr, timeout);
   this->set_sample_rate(SR::SPS_1600);
   this->set_gain(GAIN::TWO);
   this->alert_pin = alert_pin;
 }
 
 bool ADS1015::reset() {
-  this->dev::I2CDevice::reset();
+  this->I2CDevice::reset();
   while (this->is_functional()) {
     static uint8_t const thresh[6] = {0x02, 0x00, 0x00, 0x03, 0xFF, 0xFF};
     this->i2c_begin_transmission();
@@ -86,3 +89,5 @@ bool ADS1015::read(CHANNEL channel, int16_t &val) {
   this->start_read(channel);
   return this->end_read(val);
 }
+}  // namespace dev
+}  // namespace adcs

--- a/src/adcs/dev/ADS1015.hpp
+++ b/src/adcs/dev/ADS1015.hpp
@@ -1,6 +1,6 @@
 //
-// lib/ADS1015/ADS1015.hpp
-// ADCS
+// src/adcs/dev/ADS1015.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -13,17 +13,17 @@
 // TODO :
 // Test version 2_0 with the differential reads as well
 
-#ifndef ADCS_LIB_ADS1015_ADS1015_HPP_
-#define ADCS_LIB_ADS1015_ADS1015_HPP_
+#ifndef SRC_ADCS_DEV_ADS1015_HPP_
+#define SRC_ADCS_DEV_ADS1015_HPP_
 
-#include <I2CDevice.hpp>
+#include "I2CDevice.hpp"
 
-/** @addtogroup lib
- *  @{ */
+namespace adcs {
+namespace dev {
 
 /** @class ADS1015
  *  Single shot conversion driver for the ADS1015 using the alert/ready pin. */
-class ADS1015 : public dev::I2CDevice {
+class ADS1015 : public I2CDevice {
  public:
   /** @enum ADDR
    *  Possible address values for the ADS1015. */
@@ -116,7 +116,7 @@ class ADS1015 : public dev::I2CDevice {
   /** ADC gain value. */
   GAIN gain;
 };
-
-/** @} */
+}  // namespace dev
+}  // namespace adcs
 
 #endif

--- a/src/adcs/dev/Device.hpp
+++ b/src/adcs/dev/Device.hpp
@@ -1,6 +1,6 @@
 //
-// lib/Devices/Device.hpp
-// ADCS
+// src/adcs/dev/Device.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Tanishq Aggarwal  ta335@cornell.edu
@@ -11,13 +11,12 @@
 // Cornell Univeristy
 //
 
-#ifndef ADCS_LIB_DEVICES_DEVICE_HPP_
-#define ADCS_LIB_DEVICES_DEVICE_HPP_
+#ifndef SRC_ADCS_DEV_DEVICE_HPP_
+#define SRC_ADCS_DEV_DEVICE_HPP_
 
-/** @addtogroup lib 
- *  @{ */
-
+namespace adcs {
 namespace dev {
+
 /** @class Device
  *  Defines generic behavior all ADCS peripherials share. This includes a setup
  *  function, reset function, disable function, and an is functional check. */
@@ -43,7 +42,6 @@ class Device {
   bool functional;
 };
 }  // namespace dev
-
-/** @} */
+}  // namespace adcs
 
 #endif

--- a/src/adcs/dev/I2CDevice.hpp
+++ b/src/adcs/dev/I2CDevice.hpp
@@ -1,6 +1,6 @@
 //
-// lib/Devices/I2CDevice.hpp
-// ADCS
+// src/adcs/dev/I2CDevice.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol         kpk63@cornell.edu
@@ -10,14 +10,12 @@
 // Cornell Univeristy
 //
 
-#ifndef ADCS_LIB_DEVICES_I2CDEVICE_HPP_
-#define ADCS_LIB_DEVICES_I2CDEVICE_HPP_
+#ifndef SRC_ADCS_DEV_I2CDEVICE_HPP_
+#define SRC_ADCS_DEV_I2CDEVICE_HPP_
 
 #include "Device.hpp"
-#include <i2c_t3.h>
 
-/** @addtogroup lib
- *  @{ */
+#include <i2c_t3.h>
 
 #ifndef DEV_I2C_ERROR_COUNT
 /** Specifies the number of consecutive failures that marks an \c I2CDevice as
@@ -31,7 +29,9 @@
 #define DEV_I2C_TIMEOUT 10000
 #endif
 
+namespace adcs {
 namespace dev {
+
 /** @class I2CDevice
  *  Defines a common interface and error tracking behavior for all peripherials
  *  communicating over I2C. The function calls are largely based on the i2c_t3
@@ -127,8 +127,7 @@ class I2CDevice : public Device {
   bool error_acc;
 };
 }  // namespace dev
-
-/** @} */
+}  // namespace adcs
 
 #include "I2CDevice.inl"
 

--- a/src/adcs/dev/I2CDevice.inl
+++ b/src/adcs/dev/I2CDevice.inl
@@ -1,6 +1,6 @@
 //
-// lib/Devices/I2CDevice.inl
-// ADCS
+// src/adcs/dev/I2CDevice.inl
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol         kpk63@cornell.edu
@@ -12,6 +12,7 @@
 
 #include "I2CDevice.hpp"
 
+namespace adcs {
 namespace dev {
 
 inline bool I2CDevice::reset() {
@@ -37,7 +38,7 @@ inline bool I2CDevice::i2c_peek_errors() {
 inline bool I2CDevice::i2c_pop_errors() {
   if (this->i2c_peek_errors())
     if (++this->error_count >= DEV_I2C_ERROR_COUNT) 
-      this->dev::Device::disable(); //don't attempt further I2C comms
+      this->Device::disable(); //don't attempt further I2C comms
   bool temp = this->i2c_peek_errors();
   this->error_acc = 0;
   return temp;
@@ -97,3 +98,4 @@ inline void I2CDevice::i2c_read(T *data, unsigned int len) {
   this->error_acc = (this->error_acc || err);
 }
 }  // namespace dev
+}  // namespace adcs

--- a/src/adcs/dev/LIS2MDLTR.cpp
+++ b/src/adcs/dev/LIS2MDLTR.cpp
@@ -1,6 +1,6 @@
 //
-// lib/LIS2MDLTR/LIS2MDLTR.cpp
-// ADCS
+// src/adcs/dev/LIS2MDLTR.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Anusha Choudhury ac978@cornell.edu
@@ -13,12 +13,15 @@
 
 #include "LIS2MDLTR.hpp"
 
+namespace adcs {
+namespace dev {
+
 void LIS2MDLTR::setup(i2c_t3 *wire, unsigned long timeout) {
-  this->dev::I2CDevice::setup(wire, 0b0011110, timeout);
+  this->I2CDevice::setup(wire, 0b0011110, timeout);
 }
 
 bool LIS2MDLTR::reset() {
-  this->dev::I2CDevice::reset();
+  this->I2CDevice::reset();
   while (this->is_functional()) {
     this->i2c_begin_transmission();
     this->i2c_write(REG::CFG_A);
@@ -34,7 +37,7 @@ bool LIS2MDLTR::reset() {
 }
 
 void LIS2MDLTR::disable() {
-  this->dev::I2CDevice::disable();
+  this->I2CDevice::disable();
   this->i2c_begin_transmission();
   this->i2c_write(REG::CFG_A);
   this->i2c_write((uint8_t)(this->sample_rate | 0b11));
@@ -65,7 +68,8 @@ bool LIS2MDLTR::read() {
   this->b_vec[2] = (buffer[4] << 0) | (buffer[5] << 8);
   return true;
 }
-
+}  // namespace dev
+}  // namespace adcs
 
 // /*
 //     Magnetometer::Magnetometer(i2c_t3& wire,uint8_t addr,unsigned long timeout)

--- a/src/adcs/dev/LIS2MDLTR.hpp
+++ b/src/adcs/dev/LIS2MDLTR.hpp
@@ -1,6 +1,6 @@
 //
-// lib/LIS2MDLTR/LIS2MDLTR.hpp
-// ADCS
+// src/adcs/dev/LIS2MDLTR.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Anusha Choudhury ac978@cornell.edu
@@ -11,16 +11,19 @@
 // Cornell Univeristy
 //
 
-#ifndef PAN_ADCS_LIB_LIS2MDLTR_LIS2MDLTR_HPP_
-#define PAN_ADCS_LIB_LIS2MDLTR_LIS2MDLTR_HPP_
+#ifndef SRC_ADCS_DEV_LIS2MDLTR_HPP_
+#define SRC_ADCS_DEV_LIS2MDLTR_HPP_
 
-#include <I2CDevice.hpp>
+#include "I2CDevice.hpp"
+
+namespace adcs {
+namespace dev {
 
 /** @class LIS2MDLTR
  *  Driver operating the LIS2MDLTR magnetometer in continuous mode with variable
  *  sample rate. There is also a calibration function to handle
  *  temperature/intrinsic bias. */
-class LIS2MDLTR : public dev::I2CDevice {
+class LIS2MDLTR : public I2CDevice {
  public:
   /** @enum REG
    *  Possible addresses for the registers of the magnetometer. **/
@@ -117,5 +120,7 @@ class LIS2MDLTR : public dev::I2CDevice {
   /** Magnetic field sample rate. */
   uint8_t sample_rate;
 };
+}  // namespace dev
+}  // namespace adcs
 
 #endif

--- a/src/adcs/dev/LSM6DSM.cpp
+++ b/src/adcs/dev/LSM6DSM.cpp
@@ -12,12 +12,15 @@
 
 #include "LSM6DSM.hpp"
 
+namespace adcs {
+namespace dev {
+
 void LSM6DSM::setup(i2c_t3 *wire, uint8_t addr, unsigned long timeout) {
-  this->dev::I2CDevice::setup(wire, addr, timeout);
+  this->I2CDevice::setup(wire, addr, timeout);
 }
 
 bool LSM6DSM::reset() {
-  this->dev::I2CDevice::reset();
+  this->I2CDevice::reset();
   while (this->is_functional()) {
     this->i2c_begin_transmission();
     this->i2c_write(REG::CTRL2_G);
@@ -30,7 +33,7 @@ bool LSM6DSM::reset() {
 }
 
 void LSM6DSM::disable() {
-  this->dev::I2CDevice::disable();
+  this->I2CDevice::disable();
   this->i2c_begin_transmission();
   this->i2c_write(REG::CTRL2_G);
   this->i2c_write(0x00); // 250 dps, Power down
@@ -63,3 +66,5 @@ bool LSM6DSM::read() {
   this->omega[2] = buffer[6] | (buffer[7] << 8);
   return true;  
 }
+}  // namespace dev
+}  // namespace adcs

--- a/src/adcs/dev/LSM6DSM.hpp
+++ b/src/adcs/dev/LSM6DSM.hpp
@@ -1,6 +1,6 @@
 //
-// lib/LSM6DSM/LSM6DSM.hpp
-// ADCS
+// src/adcs/dev/LSM6DSM.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -10,8 +10,8 @@
 // Cornell Univeristy
 //
 
-#ifndef ADCS_LIB_LSM6DSM_LSM6DSM_HPP_
-#define ADCS_LIB_LSM6DSM_LSM6DSM_HPP_
+#ifndef SRC_ADCS_DEV_LSM6DSM_HPP_
+#define SRC_ADCS_DEV_LSM6DSM_HPP_
 
 // TODO : make sure the driver resets setting upon failure
 // Checking data ready will be false until the gryo filter has settled
@@ -19,16 +19,16 @@
 
 // Outputs unsigned in the range of +/- 16 gauss
 
-/** @addtogroup lib 
- *  @{ */
+#include "I2CDevice.hpp"
 
-#include <I2CDevice.hpp>
+namespace adcs {
+namespace dev {
 
 /** @class LSM6DSM
  *  Driver to interface with the gyroscope portion of the LSM6DSM. This driver
  *  operates the IC with a sample rate of 52 Hz to match the on board
  *  temperature sensor. */
-class LSM6DSM : public dev::I2CDevice {
+class LSM6DSM : public I2CDevice {
  public:
   /** @enum ADDR
    *  Enumerates the possible slave addresses for the gyroscope. */
@@ -95,7 +95,7 @@ class LSM6DSM : public dev::I2CDevice {
   /** Gyroscope temperature value. */
   int16_t temp;
 };
-
-/** @} */
+}  // namespace dev
+}  // namespace adcs
 
 #endif

--- a/src/adcs/dev/MMC34160PJ.cpp
+++ b/src/adcs/dev/MMC34160PJ.cpp
@@ -1,6 +1,6 @@
 //
-// lib/MMC34160PJ/MMC34160PJ.cpp
-// ADCS
+// src/adcs/dev/MMC34160PJ.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -12,8 +12,11 @@
 
 #include "MMC34160PJ.hpp"
 
+namespace adcs {
+namespace dev {
+
 void MMC34160PJ::setup(i2c_t3 *wire, unsigned long timeout) {
-  this->dev::I2CDevice::setup(wire, 0x30, timeout);
+  this->I2CDevice::setup(wire, 0x30, timeout);
   this->sample_rate = MMC34160PJ::SR::HZ_50;
   this->offset[0] = 0x00;
   this->offset[1] = 0x00;
@@ -21,7 +24,7 @@ void MMC34160PJ::setup(i2c_t3 *wire, unsigned long timeout) {
 }
 
 bool MMC34160PJ::reset() {
-  this->dev::I2CDevice::reset();
+  this->I2CDevice::reset();
   while (this->is_functional()) {
     this->i2c_begin_transmission();
     this->i2c_write(MMC34160PJ::REG::INTERNAL_CONTROL_0);
@@ -37,7 +40,7 @@ void MMC34160PJ::disable() {
   this->i2c_write(MMC34160PJ::REG::INTERNAL_CONTROL_0);
   this->i2c_write(0x00); // Disable continous measurement mode
   this->i2c_end_transmission();
-  this->dev::I2CDevice::disable();
+  this->I2CDevice::disable();
 }
 
 void MMC34160PJ::calibrate() {
@@ -123,3 +126,5 @@ bool MMC34160PJ::single_read(uint16_t *array) {
   for (unsigned int i = 0; i < 3; i++) array[i] = this->b_vec[i];
   return true;
 }
+}  // namespace dev
+}  // namespace adcs

--- a/src/adcs/dev/MMC34160PJ.hpp
+++ b/src/adcs/dev/MMC34160PJ.hpp
@@ -1,6 +1,6 @@
 //
-// lib/MMC34160PJ/MMC34160PJ.hpp
-// ADCS
+// src/adcs/dev/MMC34160PJ.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -12,19 +12,19 @@
 
 // TODO : Calibrate function
 
-#ifndef PAN_ADCS_LIB_MMC34160PJ_MMC34160PJ_HPP_
-#define PAN_ADCS_LIB_MMC34160PJ_MMC34160PJ_HPP_
+#ifndef SRC_ADCS_DEV_MMC34160PJ_HPP_
+#define SRC_ADCS_DEV_MMC34160PJ_HPP_
 
-/** @addtogroup lib
- *  @} */
+#include "I2CDevice.hpp"
 
-#include <I2CDevice.hpp>
+namespace adcs {
+namespace dev {
 
 /** @class MMC34160PJ
  *  Driver operating the MMC34160PJ magnetometer in single shot mode with
  *  variable sample rate. There is also a calibration function to handle
  *  temperature/intrinsic bias. */
-class MMC34160PJ : public dev::I2CDevice {
+class MMC34160PJ : public I2CDevice {
  public:
   /** @enum REG
    *  Enumerates all possible register addresses for the magnetometer. */
@@ -110,7 +110,7 @@ class MMC34160PJ : public dev::I2CDevice {
   /** Magnetomter offset calibration value. */
   uint16_t offset[3];
 };
-
-/** @} */
+}  // namespace dev
+}  // namespace adcs
 
 #endif

--- a/src/adcs/dev/Magnetorquer.cpp
+++ b/src/adcs/dev/Magnetorquer.cpp
@@ -1,6 +1,6 @@
 //
-// lib/MTR/MTR.cpp
-// ADCS
+// src/adcs/dev/Magnetorquer.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -11,7 +11,11 @@
 //
 
 #include "Magnetorquer.hpp"
+
 #include <Arduino.h>
+
+namespace adcs {
+namespace dev {
 
 void Magnetorquer::setup(unsigned int f_pin, unsigned int r_pin) {
   this->f_pin = f_pin;
@@ -19,13 +23,13 @@ void Magnetorquer::setup(unsigned int f_pin, unsigned int r_pin) {
 }
 
 bool Magnetorquer::reset() {
-  this->dev::Device::reset();
+  this->Device::reset();
   this->actuate(0);
   return true;
 }
 
 void Magnetorquer::disable() {
-  this->dev::Device::disable();
+  this->Device::disable();
   this->actuate(0);
 }
 
@@ -38,3 +42,5 @@ void Magnetorquer::actuate(int signed_pwm) {
     analogWrite(r_pin, -signed_pwm);
   }
 }
+}  // namespace dev
+}  // namespace adcs

--- a/src/adcs/dev/Magnetorquer.hpp
+++ b/src/adcs/dev/Magnetorquer.hpp
@@ -1,6 +1,6 @@
 //
-// lib/MTR/MTR.hpp
-// ADCS
+// src/adcs/dev/Magnetorquer.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -10,18 +10,18 @@
 // Cornell Univeristy
 //
 
-#ifndef ADCS_LIB_MTR_MAGNETORQUER_HPP_
-#define ADCS_LIB_MTR_MAGNETORQUER_HPP_
+#ifndef SRC_ADCS_DEV_MAGNETORQUER_HPP_
+#define SRC_ADCS_DEV_MAGNETORQUER_HPP_
 
-/** @addtogroup lib
- *  @{ */
+#include "Device.hpp"
 
-#include <Device.hpp>
+namespace adcs {
+namespace dev {
 
 /** \class MTR
  *  Encapsulates the signed PWM actuation behavior of a magnetorquer and
  *  abstracts away the H-bridge. */
-class Magnetorquer : public dev::Device {
+class Magnetorquer : public Device {
  public:
   /** Sets the forward and backward pins associated with this magnetorquer. */
   void setup(unsigned int f_pin, unsigned int r_pin);
@@ -42,7 +42,7 @@ class Magnetorquer : public dev::Device {
   /** Reverse enable pin. */
   unsigned int r_pin;
 };
-
-/** @} */
+}  // namespace dev
+}  // namespace adcs
 
 #endif

--- a/src/adcs/dev/MaxonEC45.cpp
+++ b/src/adcs/dev/MaxonEC45.cpp
@@ -1,6 +1,6 @@
 //
-// lib/MaxonEC45/MaxonEC45.cpp
-// ADCS
+// src/adcs/dev/MaxonEC45.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol          kpk63@cornell.edu
@@ -11,7 +11,11 @@
 //
 
 #include "MaxonEC45.hpp"
+
 #include <Arduino.h>
+
+namespace adcs {
+namespace dev {
 
 void MaxonEC45::setup(unsigned int cw_pin, unsigned int ccw_pin, unsigned int speed_pin,
                       AD5254 *potentiometer, void (AD5254::*const set_r)(uint8_t)) {
@@ -23,7 +27,7 @@ void MaxonEC45::setup(unsigned int cw_pin, unsigned int ccw_pin, unsigned int sp
 }
 
 bool MaxonEC45::reset() {
-  this->dev::Device::reset();
+  this->Device::reset();
   this->set_axl_ramp(0);
   this->set_speed(1000);
   this->stop();
@@ -31,7 +35,7 @@ bool MaxonEC45::reset() {
 }
 
 void MaxonEC45::disable() {
-  this->dev::Device::disable();
+  this->Device::disable();
   this->set_axl_ramp(0);
   this->set_speed(1000);
   this->stop();
@@ -54,3 +58,5 @@ void MaxonEC45::stop() {
   digitalWrite(this->cw_pin, LOW);
   digitalWrite(this->ccw_pin, LOW);
 }
+}  // namespace dev
+}  // namespace adcs

--- a/src/adcs/dev/MaxonEC45.hpp
+++ b/src/adcs/dev/MaxonEC45.hpp
@@ -1,6 +1,6 @@
 //
-// lib/MaxonEC45/MaxonEC45.hpp
-// ADCS
+// src/adcs/dev/MaxonEC45.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol          kpk63@cornell.edu
@@ -10,16 +10,20 @@
 // Cornell Univeristy
 //
 
-#ifndef ADCS_LIB_MAXONEC45_HPP_
-#define ADCS_LIB_MAXONEC45_HPP_
+#ifndef SRC_ADCS_DEV_MAXONEC45_HPP_
+#define SRC_ADCS_DEV_MAXONEC45_HPP_
 
-#include <AD5254.hpp>
-#include <Device.hpp>
+#include "AD5254.hpp"
+#include "Device.hpp"
+
 #include <Servo.h>
+
+namespace adcs {
+namespace dev {
 
 /** @class MaxonEC45
  *  */
-class MaxonEC45 : public dev::Device {
+class MaxonEC45 : public Device {
  public:
   /** Sets up this mootor on the following clockwise enable, counterclockwise
    *  enable, speed servo pin, potentiometer, and potentiometer rdac channel. */
@@ -61,5 +65,7 @@ class MaxonEC45 : public dev::Device {
   /** Current acceleration ramp setting. */
   uint8_t axl_ramp;
 };
+}  // namespace dev
+}  // namespace adcs
 
 #endif

--- a/src/adcs/havt.hpp
+++ b/src/adcs/havt.hpp
@@ -1,6 +1,6 @@
 //
-// include/havt.hpp
-// ADCS
+// src/adcs/havt.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Shihao Cao  sfc72@cornell.edu
@@ -10,16 +10,15 @@
 // Cornell Univeristy
 //
 
-#ifndef PAN_ADCS_INCLUDE_HAVT_HPP_
-#define PAN_ADCS_INCLUDE_HAVT_HPP_
+#ifndef SRC_ADCS_HAVT_HPP_
+#define SRC_ADCS_HAVT_HPP_
 
-#include <Device.hpp> // for dev_ptrs
-#include <adcs_constants.hpp> // include necessary so that havt::max_device is defined
+#include "constants.hpp" // include necessary so that havt::max_device is defined
+#include "dev/Device.hpp" // for dev_ptrs
+
 #include <bitset>
 
-/** @namespace havt
- *  Holds functinoality to read the is_functional() from each device aboard the ADCS Box
- *  Also contains functionality to command resets and disables for each device */
+namespace adcs {
 namespace havt {
 
 /**
@@ -39,15 +38,16 @@ extern std::bitset<havt::max_devices> internal_table;
  * @brief Uses dev_ptrs to call is_functional() of each device and store into internal_table
  * 
  */
-extern void update_read_table();
+void update_read_table();
 
 /**
  * @brief Requests reset() or disable() if cmd_table differs with internal_table
  * 
  * Commands a reset() or disable() based on each specific device with a difference
  */
-extern void execute_cmd_table(const std::bitset<havt::max_devices>& cmd_table);
+void execute_cmd_table(const std::bitset<havt::max_devices>& cmd_table);
 
 }  // namespace havt
+}  // namespace adcs
 
 #endif

--- a/src/adcs/havt_devices.hpp
+++ b/src/adcs/havt_devices.hpp
@@ -1,0 +1,47 @@
+//
+// src/adcs/havt_devices.hpp
+// FlightSoftware
+//
+// Contributors:
+//   Shihao Cao     sfc72@cornell.edu
+//
+// Pathfinder for Autonomous Navigation
+// Space Systems Design Studio
+// Cornell Univeristy
+//
+
+#ifndef SRC_ADCS_HAVT_DEVICES_HPP_
+#define SRC_ADCS_HAVT_DEVICES_HPP_
+
+namespace adcs {
+namespace havt {
+
+/** @enum Index
+ *  Enumerates the bitset address of the devices in the havt table
+ *  The first value corresponds to bitset[0]  */
+enum Index : unsigned char {
+  IMU_GYR,
+  IMU_MAG1,
+  IMU_MAG2,
+  MTR1,
+  MTR2,
+  MTR3,
+  RWA_POT,
+  RWA_WHEEL1,
+  RWA_WHEEL2,
+  RWA_WHEEL3,
+  RWA_ADC1,
+  RWA_ADC2,
+  RWA_ADC3,
+  SSA_ADC1,
+  SSA_ADC2,
+  SSA_ADC3,
+  SSA_ADC4,
+  SSA_ADC5,
+  //GYRO_HEATER, <- uncomment when device is added
+  _LENGTH
+};
+}  // namespace havt
+}  // namespace adcs
+
+#endif

--- a/src/adcs/imu.cpp
+++ b/src/adcs/imu.cpp
@@ -1,6 +1,6 @@
 //
-// src/imu.cpp
-// ADCS
+// src/adcs/imu.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -14,19 +14,19 @@
 #define DEBUG
 #endif
 
-#include <adcs_constants.hpp>
+#include "constants.hpp"
+#include "imu.hpp"
+#include "imu_calibration.hpp"
+#include "imu_config.hpp"
+#include "utl/convert.hpp"
+#include "utl/debug.hpp"
 
-#include <adcs/imu.hpp>
-#include <adcs/imu_calibration.hpp>
-#include <adcs/imu_config.hpp>
-#include <adcs/utl/convert.hpp>
-#include <adcs/utl/debug.hpp>
-
+namespace adcs {
 namespace imu {
 
-LIS2MDLTR mag1;
+dev::LIS2MDLTR mag1;
 
-MMC34160PJ mag2;
+dev::MMC34160PJ mag2;
 
 lin::Vector3f mag_rd({
   0.0f,
@@ -81,7 +81,7 @@ static unsigned char update_mag(unsigned char mode, float mag_flt) {
   return return_mode;
 }
 
-LSM6DSM gyr;
+dev::LSM6DSM gyr;
 
 lin::Vector3f gyr_rd({
   0.0f,
@@ -130,7 +130,7 @@ void setup() {
 
   // Setup and initialize the first magnetometer
   mag1.setup(mag1_wire, mag1_timeout);
-  mag1.set_sample_rate(LIS2MDLTR::SR::HZ_50);
+  mag1.set_sample_rate(dev::LIS2MDLTR::SR::HZ_50);
   mag1.reset();
 #ifdef DEBUG
   if (mag1.is_functional()) DEBUG_printlnF("#imu> Magnetometer 1 inititated")
@@ -139,7 +139,7 @@ void setup() {
 
   // Setup and initialize the second magnetometer
   mag2.setup(mag2_wire, mag2_timeout);
-  mag2.set_sample_rate(MMC34160PJ::SR::HZ_50);
+  mag2.set_sample_rate(dev::MMC34160PJ::SR::HZ_50);
   mag2.reset();
 #ifdef DEBUG
   if (mag2.is_functional()) DEBUG_printlnF("#imu> Magnetometer 2 inititated")
@@ -164,3 +164,4 @@ unsigned char update_sensors(unsigned char mode, float mag_flt, float gyr_flt,
   return update_mag(mode, mag_flt);
 }
 }  // namespace imu
+}  // namespace adcs

--- a/src/adcs/imu.hpp
+++ b/src/adcs/imu.hpp
@@ -1,6 +1,6 @@
 //
-// include/imu.hpp
-// ADCS
+// src/adcs/imu.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -10,33 +10,31 @@
 // Cornell Univeristy
 //
 
-#ifndef PAN_ADCS_INCLUDE_IMU_HPP_
-#define PAN_ADCS_INCLUDE_IMU_HPP_
+#ifndef SRC_ADCS_IMU_HPP_
+#define SRC_ADCS_IMU_HPP_
+
+#include "dev/LIS2MDLTR.hpp"
+#include "dev/LSM6DSM.hpp"
+#include "dev/MMC34160PJ.hpp"
 
 #include <i2c_t3.h>
 #include <lin.hpp>
-#include <LIS2MDLTR.hpp>
-#include <LSM6DSM.hpp>
-#include <MMC34160PJ.hpp>
 
-/** @namespace imu
- *  Holds all constants and functions directly related to the IMU assembly
- *  within the ADCS system. This includes the two magnetomters, gyroscope, and
- *  temperature feedback control system for the gyroscope. */
+namespace adcs {
 namespace imu {
 
 /** Magnetometer number one device. */
-extern LIS2MDLTR mag1;
+extern dev::LIS2MDLTR mag1;
 
 /** Magnetometer number two device. */
-extern MMC34160PJ mag2;
+extern dev::MMC34160PJ mag2;
 
 /** Current magnetic field reading in Tesla in the body frame of the
  *  spacecraft. */
 extern lin::Vector3f mag_rd;
 
 /** Gyroscope device. */
-extern LSM6DSM gyr;
+extern dev::LSM6DSM gyr;
 
 /** Current gyroscope reading in radians per second in the body frame of the
  *  spacecraft. */
@@ -48,16 +46,17 @@ extern float gyr_temp_rd;
 /** @fn setup
  *  Initializes the magnetomters and gyroscope IC including calibration. This
  *  will take a few hundred milliseconds to complete. */
-extern void setup();
+void setup();
 
 /** @fn update_sensors
  *  @return Updated IMU assembly mode.
  *  See the documentation on OneDrive for more details about how the system
  *  behaves according to the mode value. */
-extern unsigned char update_sensors(unsigned char mode, float mag_flt,
-    float gyr_flt, float gyr_temp_eq, float gyr_temp_flt, float gry_temp_k_p,
+unsigned char update_sensors(unsigned char mode, float mag_flt, float gyr_flt,
+    float gyr_temp_eq, float gyr_temp_flt, float gry_temp_k_p,
     float gyr_temp_k_i, float gyr_temp_k_d);
 
 }  // namespace imu
+}  // namespace adcs
 
 #endif

--- a/src/adcs/imu_calibration.cpp
+++ b/src/adcs/imu_calibration.cpp
@@ -1,6 +1,6 @@
 //
-// src/imu_calibration.cpp
-// ADCS
+// src/adcs/imu_calibration.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -25,8 +25,9 @@
  * 
  */
 
-#include <adcs/imu_calibration.hpp>
+#include "imu_calibration.hpp"
 
+namespace adcs {
 namespace imu {
 
 // Commented out to avoid -Werror=unused-variable
@@ -93,3 +94,4 @@ void calibrate(lin::Vector3f &omega, float temp) {
   omega = transformation * omega + offset;
 }
 }  // namespace imu
+}  // namespace adcs

--- a/src/adcs/imu_calibration.hpp
+++ b/src/adcs/imu_calibration.hpp
@@ -1,6 +1,6 @@
 //
-// include/imu_calibration.hpp
-// ADCS
+// src/adcs/imu_calibration.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol         kpk63@cornell.edu
@@ -12,11 +12,12 @@
 
 // TODO : Determine imu read transformations
 
-#ifndef ADCS_INCLUDE_IMU_CALIBRATION_HPP_
-#define ADCS_INCLUDE_IMU_CALIBRATION_HPP_
+#ifndef SRC_ADCS_IMU_CALIBRATION_HPP_
+#define SRC_ADCS_IMU_CALIBRATION_HPP_
 
 #include <lin.hpp>
 
+namespace adcs {
 namespace imu {
 
 /** @fn calibrate
@@ -24,8 +25,9 @@ namespace imu {
  *  @param[in] temp Temperature in celcius of the gyroscope.
  *  Transforms the omega vector in the body frame of the gyroscope to perform a
  *  calibration of the sensor. */
-extern void calibrate(lin::Vector3f &omega, float temp);
+void calibrate(lin::Vector3f &omega, float temp);
 
 }  // namespace imu
+}  // namespace adcs
 
 #endif

--- a/src/adcs/imu_config.hpp
+++ b/src/adcs/imu_config.hpp
@@ -1,6 +1,6 @@
 //
-// include/imu_config.hpp
-// ADCS
+// src/adcs/imu_config.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol         kpk63@cornell.edu
@@ -12,19 +12,21 @@
 
 // TODO : Determine imu read transformations
 
-#ifndef ADCS_INCLUDE_IMU_CONFIG_HPP_
-#define ADCS_INCLUDE_IMU_CONFIG_HPP_
+#ifndef SRC_ADCS_IMU_CONFIG_HPP_
+#define SRC_ADCS_IMU_CONFIG_HPP_
+
+#include "dev/LSM6DSM.hpp"
 
 #include <i2c_t3.h>
 #include <lin.hpp>
-#include <LSM6DSM.hpp>
 
+namespace adcs {
 namespace imu {
 
 /** i2c bus the gyroscope communicate on. */
 static i2c_t3 *const gyr_wire = &Wire2;
 /** i2c address of the gyroscope. */
-static unsigned char const gyr_addr = LSM6DSM::ADDR::GND;
+static unsigned char const gyr_addr = dev::LSM6DSM::ADDR::GND;
 /** i2c timeout in microseconds used by the gyroscope. */
 static unsigned long const gyr_timeout = 10000;
 
@@ -93,7 +95,7 @@ static lin::Matrix3x3f const mag2_to_body(
 static_assert(false, "Must define PAN_LEADER or PAN_FOLLOWER");
 #endif
 );
-
 }  // namespace imu
+}  // namespace adcs
 
 #endif

--- a/src/adcs/main.cpp
+++ b/src/adcs/main.cpp
@@ -1,6 +1,6 @@
 //
-// src/main.cpp
-// ADCS
+// src/adcs/main.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -28,22 +28,24 @@
 #define DEBUG
 #endif
 
-#include <adcs/imu.hpp>
-#include <adcs/mtr.hpp>
-#include <adcs/rwa.hpp>
-#include <adcs/ssa.hpp>
-#include <adcs/havt.hpp>
-#include <adcs/state.hpp>
-#include <adcs/state_controller.hpp>
-#include <adcs/utl/debug.hpp>
+#include "constants.hpp"
+#include "havt.hpp"
+#include "havt_devices.hpp"
+#include "imu.hpp"
+#include "mtr.hpp"
+#include "rwa.hpp"
+#include "ssa.hpp"
+#include "state.hpp"
+#include "state_controller.hpp"
+#include "utl/debug.hpp"
 
 #include <Arduino.h>
 #include <i2c_t3.h>
 #include <lin.hpp>
 
-#include <adcs_constants.hpp>
-#include <adcs_havt_devices.hpp>
 #include <bitset>
+
+using namespace adcs;
 
 // TODO : Look into the proper initialization for the slave i2c bus and whether
 //        a clock frequency needs to be included
@@ -184,7 +186,6 @@ void loop() {
   update_rwa();  DEBUG_printF(",")
   update_ssa();  DEBUG_printF(",")
   update_havt(); DEBUG_printF(",") //call update havt last so that resetting devices has a chance to take place before the next control cycle
-
 
   // Append state information to the end of the CSV line
   DEBUG_print(registers.mode)     DEBUG_printF(",")

--- a/src/adcs/mtr.cpp
+++ b/src/adcs/mtr.cpp
@@ -1,6 +1,6 @@
 //
-// include/mtr/mtr.cpp
-// ADCS
+// src/adcs/mtr.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -18,18 +18,18 @@
 #define DEBUG
 #endif
 
-#include <adcs_constants.hpp>
-
-#include <adcs/mtr.hpp>
-#include <adcs/mtr_config.hpp>
-#include <adcs/utl/debug.hpp>
+#include "constants.hpp"
+#include "mtr.hpp"
+#include "mtr_config.hpp"
+#include "utl/debug.hpp"
 
 #include <Arduino.h>
 #include <array>
 
+namespace adcs {
 namespace mtr {
 
-Magnetorquer mtrs[3];
+dev::Magnetorquer mtrs[3];
 
 void setup() {
   // Set the PWM resolution and frequency
@@ -79,3 +79,4 @@ void actuate(unsigned char mtr_mode, lin::Vector3f mtr_cmd, float mtr_lim) {
       + "," + String(pwm_value[0]) + "," + String(pwm_value[1]) + "," + String(pwm_value[2]))
 }
 }  // namespace mtr
+}  // namespace adcs

--- a/src/adcs/mtr.hpp
+++ b/src/adcs/mtr.hpp
@@ -1,6 +1,6 @@
 //
-// include/mtr/mtr.hpp
-// ADCS
+// src/adcs/mtr.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -10,29 +10,30 @@
 // Cornell Univeristy
 //
 
-#ifndef PAN_ADCS_INCLUDE_MTR_HPP_
-#define PAN_ADCS_INCLUDE_MTR_HPP_
+#ifndef SRC_ADCS_MTR_HPP_
+#define SRC_ADCS_MTR_HPP_
 
-#include <Magnetorquer.hpp>
+#include "dev/Magnetorquer.hpp"
+
 #include <lin.hpp>
 
-/** @namespace mtr
- *  Contains all functionality responsible for MTR actuation. */
+namespace adcs {
 namespace mtr {
 
 /** MTR device array. */
-extern Magnetorquer mtrs[3];
+extern dev::Magnetorquer mtrs[3];
 
 /** @fn init
  *  Initiates the MTRs with a PWM of zero along each axis. */
-extern void setup();
+void setup();
 
 /** @fn actuate
  *  Actuates the MTRs according to the mode, commanded vector, and magnetic
  *  moment limit. Note that if the mode is not enabled, the magnetic torque rods
  *  will not actuate. */
-extern void actuate(unsigned char mtr_mode, lin::Vector3f mtr_cmd, float mtr_lim);
+void actuate(unsigned char mtr_mode, lin::Vector3f mtr_cmd, float mtr_lim);
 
 }  // namespace mtr
+}  // namespace adcs
 
 #endif

--- a/src/adcs/mtr_config.hpp
+++ b/src/adcs/mtr_config.hpp
@@ -1,6 +1,6 @@
 //
-// include/mtr/mtr_config.hpp
-// ADCS
+// src/adcs/mtr_config.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol         kpk63@cornell.edu
@@ -12,11 +12,12 @@
 
 // TODO : Determine magnetic torque rod command transformation
 
-#ifndef ADCS_INCLUDE_MTR_CONFIG_HPP_
-#define ADCS_INCLUDE_MTR_CONFIG_HPP_
+#ifndef SRC_ADCS_MTR_CONFIG_HPP_
+#define SRC_ADCS_MTR_CONFIG_HPP_
 
 #include <lin.hpp>
 
+namespace adcs {
 namespace mtr {
 
 /** Forward PWM pin for the zeroth magnetorquer. */
@@ -63,7 +64,7 @@ static lin::Matrix3x3f const mtr_to_body({
 static_assert(false, "Must define PAN_LEADER or PAN_FOLLOWER");
 #endif
 });
-
 }  // namespace mtr
+}  // namespace adcs
 
 #endif

--- a/src/adcs/rwa.cpp
+++ b/src/adcs/rwa.cpp
@@ -1,6 +1,6 @@
 //
-// src/rwa/rwa.cpp
-// ADCS
+// src/adcs/rwa.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -14,20 +14,20 @@
 #define DEBUG
 #endif
 
-#include <adcs_constants.hpp>
+#include "constants.hpp"
+#include "rwa.hpp"
+#include "rwa_config.hpp"
+#include "utl/convert.hpp"
+#include "utl/debug.hpp"
 
-#include <adcs/rwa.hpp>
-#include <adcs/rwa_config.hpp>
-#include <adcs/utl/convert.hpp>
-#include <adcs/utl/debug.hpp>
-
+namespace adcs {
 namespace rwa {
 
-MaxonEC45 wheels[3];
+dev::MaxonEC45 wheels[3];
 
-ADS1015 adcs[3];
+dev::ADS1015 adcs[3];
 
-AD5254 potentiometer;
+dev::AD5254 potentiometer;
 
 void setup() {
   // Setup and reset the potentiometer
@@ -43,7 +43,7 @@ void setup() {
   adcs[2].setup(adc2_wire, adc2_addr, adc2_alrt, adcx_timeout);
   // Reset the ADCs and set their gain to one
   for (auto &adc : adcs) {
-    adc.set_gain(ADS1015::GAIN::ONE);
+    adc.set_gain(dev::ADS1015::GAIN::ONE);
     adc.reset();
   }
   // Initiate reaction wheel pins to output
@@ -54,9 +54,9 @@ void setup() {
   pinMode(wheel2_cw_pin, OUTPUT);
   pinMode(wheel2_ccw_pin, OUTPUT);
   // Setup the wheels on the above pins
-  wheels[0].setup(wheel0_cw_pin, wheel0_ccw_pin, wheel0_speed_pin, &potentiometer, &AD5254::set_rdac0);
-  wheels[1].setup(wheel1_cw_pin, wheel1_ccw_pin, wheel1_speed_pin, &potentiometer, &AD5254::set_rdac1);
-  wheels[2].setup(wheel2_cw_pin, wheel2_ccw_pin, wheel2_speed_pin, &potentiometer, &AD5254::set_rdac2);
+  wheels[0].setup(wheel0_cw_pin, wheel0_ccw_pin, wheel0_speed_pin, &potentiometer, &dev::AD5254::set_rdac0);
+  wheels[1].setup(wheel1_cw_pin, wheel1_ccw_pin, wheel1_speed_pin, &potentiometer, &dev::AD5254::set_rdac1);
+  wheels[2].setup(wheel2_cw_pin, wheel2_ccw_pin, wheel2_speed_pin, &potentiometer, &dev::AD5254::set_rdac2);
   // Reset each wheel
   for (auto &wheel : wheels) wheel.reset();
 }
@@ -73,7 +73,7 @@ void update_sensors(float speed_flt, float ramp_flt) {
   // Initialize read for each enabled ADC
   for (unsigned int i = 0; i < 3; i++)
     if (adcs[i].is_functional())
-      adcs[i].start_read(ADS1015::CHANNEL::DIFFERENTIAL_0_1);
+      adcs[i].start_read(dev::ADS1015::CHANNEL::DIFFERENTIAL_0_1);
   // End read for each enabled ADC
   for (unsigned int i = 0; i < 3; i++)
     if (adcs[i].is_functional())
@@ -90,7 +90,7 @@ void update_sensors(float speed_flt, float ramp_flt) {
   // Begin read for each enabled ADC
   for (unsigned int i = 0; i < 3; i++)
     if (adcs[i].is_functional())
-      adcs[i].start_read(ADS1015::CHANNEL::SINGLE_2);
+      adcs[i].start_read(dev::ADS1015::CHANNEL::SINGLE_2);
   // End read for each enabled ADC
   for (unsigned int i = 0; i < 3; i++)
     if (adcs[i].is_functional())
@@ -154,3 +154,4 @@ void control(unsigned char rwa_mode, lin::Vector3f rwa_cmd) {
   }
 }
 }  // namespace rwa
+}  // namespace adcs

--- a/src/adcs/rwa.hpp
+++ b/src/adcs/rwa.hpp
@@ -1,6 +1,6 @@
 //
-// include/rwa/rwa.hpp
-// ADCS
+// src/adcs/rwa.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -10,26 +10,26 @@
 // Cornell Univeristy
 //
 
-#ifndef PAN_ADCS_INCLUDE_RWA_HPP_
-#define PAN_ADCS_INCLUDE_RWA_HPP_
+#ifndef SRC_ADCS_RWA_HPP_
+#define SRC_ADCS_RWA_HPP_
+
+#include "dev/AD5254.hpp"
+#include "dev/ADS1015.hpp"
+#include "dev/MaxonEC45.hpp"
 
 #include <lin.hpp>
-#include <AD5254.hpp>
-#include <ADS1015.hpp>
-#include <MaxonEC45.hpp>
 
-/** \namespace rwa
- *  Contains all functionality responsible for reaction wheel actuation. **/
+namespace adcs {
 namespace rwa {
 
 /** Potentiometer used to control the analog ramp inputs. **/
-extern AD5254 potentiometer;
+extern dev::AD5254 potentiometer;
 
 /** Reaction wheel motor drivers. **/
-extern MaxonEC45 wheels[3];
+extern dev::MaxonEC45 wheels[3];
 
 /** Analog to digital converters to read data from the motor drivers. **/
-extern ADS1015 adcs[3];
+extern dev::ADS1015 adcs[3];
 
 /** Wheel speed read by the controller. **/
 extern lin::Vector3f speed_rd;
@@ -39,20 +39,21 @@ extern lin::Vector3f ramp_rd;
 
 /** \fn setup
  *  Initializes all components involved in the reaction wheel system. **/
-extern void setup();
+void setup();
 
 /** \fn update_sensors
  *  \param[in] speed_flt
  *  \param[in] ramp_flt
  *   **/
-extern void update_sensors(float speed_flt, float ramp_flt);
+void update_sensors(float speed_flt, float ramp_flt);
 
 /** \fn control
  *  \param[in] rwa_mode
  *  \param[in] rwa_cmd
  *   */
-extern void control(unsigned char rwa_mode, lin::Vector3f rwa_cmd);
+void control(unsigned char rwa_mode, lin::Vector3f rwa_cmd);
 
 }  // namespace rwa
+}  // namespace adcs
 
 #endif

--- a/src/adcs/rwa_config.hpp
+++ b/src/adcs/rwa_config.hpp
@@ -1,6 +1,6 @@
 //
-// include/rwa/rwa_config.hpp
-// ADCS
+// src/adcs/rwa_config.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol         kpk63@cornell.edu
@@ -12,20 +12,22 @@
 
 // TODO : Determine reaction wheel command transformation
 
-#ifndef PAN_ADCS_INCLUDE_RWA_CONFIG_HPP_
-#define PAN_ADCS_INCLUDE_RWA_CONFIG_HPP_
+#ifndef SRC_ADCS_RWA_CONFIG_HPP_
+#define SRC_ADCS_RWA_CONFIG_HPP_
 
-#include <AD5254.hpp>
-#include <ADS1015.hpp>
+#include "dev/AD5254.hpp"
+#include "dev/ADS1015.hpp"
+
 #include <i2c_t3.h>
 #include <lin.hpp>
 
+namespace adcs {
 namespace rwa {
 
 /** Wire for the potentiometer. */
 static i2c_t3 *const pot_wire = &Wire1;
 /** Address for the potentiomter. */
-static unsigned char const pot_addr = AD5254::ADDR::A01;
+static unsigned char const pot_addr = dev::AD5254::ADDR::A01;
 /** Timeout in microseconds for the potentiometer. */
 static unsigned long const pot_timeout = 10000;
 
@@ -51,19 +53,19 @@ static unsigned int const wheel2_speed_pin = 21;
 /** Wire for the zeroth wheel's ADC. */
 static i2c_t3 *const adc0_wire = &Wire1;
 /** Address for the zeroth wheel's ADC. */
-static unsigned int const adc0_addr = ADS1015::ADDR::GND;
+static unsigned int const adc0_addr = dev::ADS1015::ADDR::GND;
 /** Alert pin for the zeroth wheel's ADC. */
 static unsigned int const adc0_alrt = 11;
 /** Wire for the first wheel's ADC. */
 static i2c_t3 *const adc1_wire = &Wire1;
 /** Address for the first wheel's ADC. */
-static unsigned int const adc1_addr = ADS1015::ADDR::VDD;
+static unsigned int const adc1_addr = dev::ADS1015::ADDR::VDD;
 /** Alert pin for the first wheel's ADC. */
 static unsigned int const adc1_alrt = 12;
 /** Wire for the second wheel's ADC. */
 static i2c_t3 *const adc2_wire = &Wire1;
 /** Address for the second wheel's ADC. */
-static unsigned int const adc2_addr = ADS1015::ADDR::SSCL;
+static unsigned int const adc2_addr = dev::ADS1015::ADDR::SSCL;
 /** Alert pin for the second wheel's ADC. */
 static unsigned int const adc2_alrt = 16;
 /** Timeout value in microseconds for the wheel's ADCs. */
@@ -100,7 +102,7 @@ static lin::Matrix3x3f const rwa_to_body({
 static_assert(false, "Must define PAN_LEADER or PAN_FOLLOWER");
 #endif
 });
-
 }  // namespace rwa
+}  // namespace adcs
 
 #endif

--- a/src/adcs/scripts/ADS1015_test.cpp
+++ b/src/adcs/scripts/ADS1015_test.cpp
@@ -1,6 +1,6 @@
 //
-// test/ADS1015_test.cpp
-// ADCS
+// src/adcs/scripts/ADS1015_test.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu

--- a/src/adcs/scripts/ADS1015_test.cpp
+++ b/src/adcs/scripts/ADS1015_test.cpp
@@ -10,11 +10,14 @@
 // Cornell Univeristy
 //
 
-#include <i2c_t3.h>
-#include <Arduino.h>
-#include <ADS1015.hpp>
+#include <adcs/dev/ADS1015.hpp>
 
-ADS1015 adc;
+#include <Arduino.h>
+#include <i2c_t3.h>
+
+using namespace adcs;
+
+dev::ADS1015 adc;
 
 void setup() {
   delay(5000); // Wait before starting
@@ -24,8 +27,8 @@ void setup() {
 
   // ADS Face 6 - P17
   pinMode(28, INPUT);
-  adc.setup(&Wire2, ADS1015::ADDR::SSCL, 28, 1000000);
-  adc.set_gain(ADS1015::GAIN::ONE);
+  adc.setup(&Wire2, dev::ADS1015::ADDR::SSCL, 28, 1000000);
+  adc.set_gain(dev::ADS1015::GAIN::ONE);
   if (!adc.reset()) {
     Serial.println("Error");
     while (1);
@@ -34,9 +37,9 @@ void setup() {
 }
 
 // For new version ads1015_2_0
-static ADS1015::CHANNEL channels[4] = {
-    ADS1015::CHANNEL::SINGLE_0, ADS1015::CHANNEL::SINGLE_1,
-    ADS1015::CHANNEL::SINGLE_2, ADS1015::CHANNEL::SINGLE_3};
+static dev::ADS1015::CHANNEL channels[4] = {
+    dev::ADS1015::CHANNEL::SINGLE_0, dev::ADS1015::CHANNEL::SINGLE_1,
+    dev::ADS1015::CHANNEL::SINGLE_2, dev::ADS1015::CHANNEL::SINGLE_3};
 static int n = 0;
 
 void loop() {

--- a/src/adcs/scripts/LSM6DSM_test.cpp
+++ b/src/adcs/scripts/LSM6DSM_test.cpp
@@ -1,6 +1,6 @@
 //
-// test/LSM6DSM_test.cpp
-// ADCS
+// src/adcs/scripts/LSM6DSM_test.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu

--- a/src/adcs/scripts/LSM6DSM_test.cpp
+++ b/src/adcs/scripts/LSM6DSM_test.cpp
@@ -11,20 +11,23 @@
 //
 
 #define DEBUG
+
+#include <adcs/dev/LSM6DSM.hpp>
 #include <adcs/utl/debug.hpp>
 
-#include <i2c_t3.h>
 #include <Arduino.h>
-#include <LSM6DSM.hpp>
+#include <i2c_t3.h>
 
-LSM6DSM gyro;
+using namespace adcs;
+
+dev::LSM6DSM gyro;
 
 void setup() {
   DEBUG_init(9600)
   Wire2.begin(I2C_MASTER, 0x00, I2C_PINS_3_4, I2C_PULLUP_EXT, 400000);
   delay(5000); // Allow gyroscope to start up
 
-  gyro.setup(&Wire2, LSM6DSM::ADDR::GND, 10000);
+  gyro.setup(&Wire2, dev::LSM6DSM::ADDR::GND, 10000);
   if (gyro.reset()) {
     DEBUG_printlnF("Gyroscope initialized");
   } else {

--- a/src/adcs/scripts/MMC34160PJ_test.cpp
+++ b/src/adcs/scripts/MMC34160PJ_test.cpp
@@ -15,13 +15,16 @@
 // manipulation incorect.
 
 #define DEBUG
+
+#include <adcs/dev/MMC34160PJ.hpp>
 #include <adcs/utl/debug.hpp>
 
 #include <i2c_t3.h>
 #include <Arduino.h>
-#include <MMC34160PJ.hpp>
 
-MMC34160PJ mag;
+using namespace adcs;
+
+dev::MMC34160PJ mag;
 
 void setup() {
   DEBUG_init(9600)

--- a/src/adcs/scripts/MMC34160PJ_test.cpp
+++ b/src/adcs/scripts/MMC34160PJ_test.cpp
@@ -1,6 +1,6 @@
 //
-// test/MMC34160PJ_test.cpp
-// ADCS
+// src/adcs/scripts/MMC34160PJ_test.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu

--- a/src/adcs/scripts/imu_test.cpp
+++ b/src/adcs/scripts/imu_test.cpp
@@ -20,7 +20,10 @@
 #include <adcs/utl/debug.hpp>
 
 #include <adcs_constants.hpp>
+
 #include <Arduino.h>
+
+using namespace adcs;
 
 void setup() {
   DEBUG_init(9600)

--- a/src/adcs/scripts/imu_test.cpp
+++ b/src/adcs/scripts/imu_test.cpp
@@ -1,6 +1,6 @@
 //
-// test/imu_test.cpp
-// ADCS
+// src/adcs/scripts/imu_test.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -16,10 +16,9 @@
 
 #define DEBUG
 
+#include <adcs/constants.hpp>
 #include <adcs/imu.hpp>
 #include <adcs/utl/debug.hpp>
-
-#include <adcs_constants.hpp>
 
 #include <Arduino.h>
 

--- a/src/adcs/scripts/mtr_test.cpp
+++ b/src/adcs/scripts/mtr_test.cpp
@@ -21,6 +21,8 @@
 
 #include <cmath>
 
+using namespace adcs;
+
 void setup() {
   DEBUG_init(9600);
   mtr::setup();

--- a/src/adcs/scripts/mtr_test.cpp
+++ b/src/adcs/scripts/mtr_test.cpp
@@ -1,6 +1,6 @@
 //
-// test/mtr_test.cpp
-// ADCS
+// src/adcs/scripts/mtr_test.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -12,10 +12,10 @@
 
 #define DEBUG
 
+#include <adcs/constants.hpp>
 #include <adcs/mtr.hpp>
 #include <adcs/utl/debug.hpp>
 
-#include <adcs_constants.hpp>
 #include <Arduino.h>
 #include <lin.hpp>
 

--- a/src/adcs/scripts/rwa_test.cpp
+++ b/src/adcs/scripts/rwa_test.cpp
@@ -1,6 +1,6 @@
 //
-// test/rwa_test.cpp
-// ADCS
+// src/adcs/scripts/rwa_test.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -17,10 +17,10 @@
 
 #define DEBUG
 
+#include <adcs/constants.hpp>
 #include <adcs/rwa.hpp>
 #include <adcs/utl/debug.hpp>
 
-#include <adcs_constants.hpp>
 #include <Arduino.h>
 #include <i2c_t3.h>
 #include <lin.hpp>

--- a/src/adcs/scripts/rwa_test.cpp
+++ b/src/adcs/scripts/rwa_test.cpp
@@ -25,6 +25,8 @@
 #include <i2c_t3.h>
 #include <lin.hpp>
 
+using namespace adcs;
+
 #define MAX_TORQUE rwa::max_torque
 #define SPEED_FLT 0.75f
 #define RAMP_FLT 0.75f

--- a/src/adcs/scripts/smoke_test.cpp
+++ b/src/adcs/scripts/smoke_test.cpp
@@ -1,6 +1,6 @@
 //
-// test/imu_test.cpp
-// ADCS
+// src/adcs/scripts/smoke_test.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu

--- a/src/adcs/scripts/ssa_test.cpp
+++ b/src/adcs/scripts/ssa_test.cpp
@@ -1,6 +1,6 @@
 //
-// test/ssa_test.cpp
-// ADCS
+// src/adcs/scripts/ssa_test.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu

--- a/src/adcs/scripts/ssa_test.cpp
+++ b/src/adcs/scripts/ssa_test.cpp
@@ -18,6 +18,8 @@
 #include <Arduino.h>
 #include <i2c_t3.h>
 
+using namespace adcs;
+
 void setup() {
   DEBUG_init(9600)
   Wire1.begin(I2C_MASTER, 0x00, I2C_PINS_37_38, I2C_PULLUP_EXT, 400000);

--- a/src/adcs/scripts/state_test.cpp
+++ b/src/adcs/scripts/state_test.cpp
@@ -20,6 +20,8 @@
 #include <Arduino.h>
 #include <i2c_t3.h>
 
+using namespace adcs;
+
 void setup() {
   DEBUG_init(9600) DEBUG_printlnF("Debug initialized.")
 

--- a/src/adcs/scripts/state_test.cpp
+++ b/src/adcs/scripts/state_test.cpp
@@ -1,6 +1,6 @@
 //
-// test/state_test.cpp
-// ADCS
+// src/adcs/scripts/state_test.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol         kpk63@cornell.edu

--- a/src/adcs/ssa.cpp
+++ b/src/adcs/ssa.cpp
@@ -1,6 +1,6 @@
 //
-// include/ssa.cpp
-// ADCS
+// src/adcs/ssa.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -17,15 +17,15 @@
 #define DEBUG
 #endif
 
-#include <adcs_constants.hpp>
+#include "constants.hpp"
+#include "ssa.hpp"
+#include "ssa_config.hpp"
+#include "utl/debug.hpp"
 
-#include <adcs/ssa.hpp>
-#include <adcs/ssa_config.hpp>
-#include <adcs/utl/debug.hpp>
-
+namespace adcs {
 namespace ssa {
 
-ADS1015 adcs[5];
+dev::ADS1015 adcs[5];
 
 lin::Matrix<float, 5, 4> voltages = lin::zeros<float, 5, 4>();
 
@@ -44,15 +44,15 @@ void setup() {
   adcs[4].setup(adc6_wire, adc6_addr, adc6_alrt, adcx_timeout);
   // Set the ADCs' gain value and reset them
   for (auto &adc : adcs) {
-    adc.set_gain(ADS1015::GAIN::ONE);
+    adc.set_gain(dev::ADS1015::GAIN::ONE);
     adc.reset();
   }
 }
 
 // Allows iterations across ADC channels in a loop
-static ADS1015::CHANNEL const channels[4] = {
-  ADS1015::CHANNEL::SINGLE_0, ADS1015::CHANNEL::SINGLE_1,
-  ADS1015::CHANNEL::SINGLE_2, ADS1015::CHANNEL::SINGLE_3
+static dev::ADS1015::CHANNEL const channels[4] = {
+  dev::ADS1015::CHANNEL::SINGLE_0, dev::ADS1015::CHANNEL::SINGLE_1,
+  dev::ADS1015::CHANNEL::SINGLE_2, dev::ADS1015::CHANNEL::SINGLE_3
 };
 
 void update_sensors(float adc_flt) {
@@ -111,3 +111,4 @@ unsigned char calculate_sun_vector(lin::Vector3f &sun_vec) {
   return SSAMode::SSA_COMPLETE;
 }
 }  // namespace ssa
+}  // namespace adcs

--- a/src/adcs/ssa.hpp
+++ b/src/adcs/ssa.hpp
@@ -1,6 +1,6 @@
 //
-// include/ssa.hpp
-// ADCS
+// src/adcs/ssa.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol         kpk63@cornell.edu
@@ -16,18 +16,18 @@
 // Determine least squares row threshold
 // Review timeout value
 
-#ifndef PAN_ADCS_INCLUDE_SSA_HPP_
-#define PAN_ADCS_INCLUDE_SSA_HPP_
+#ifndef SRC_ADCS_SSA_HPP_
+#define SRC_ADCS_SSA_HPP_
 
-#include <ADS1015.hpp>
+#include "dev/ADS1015.hpp"
+
 #include <lin.hpp>
 
-/** @namespace ssa
- *  Contains all functions responsible for sun sensor actuation. */
+namespace adcs {
 namespace ssa {
 
 /** ADC device array. */
-extern ADS1015 adcs[5];
+extern dev::ADS1015 adcs[5];
 
 /** Matrix storing sun sensor voltage readings. Row position indicates ADC
  *  membership and columns map to channel number. */
@@ -36,13 +36,13 @@ extern lin::Matrix<float, 5, 4> voltages;
 /** @fn setup
  *  Initiates all the ADCs but does not initialize voltage values in the
  *  in the voltage vector. */
-extern void setup();
+void setup();
 
 /** @fn actuate
  *  Takes a round of sensor readings with the given exponential filter constant.
  *  The new voltages can be accessed via the extern voltages vector.
  *  @param[in] adc_flt Exponential filter applied to the voltage readings. */
-extern void update_sensors(float adc_flt);
+void update_sensors(float adc_flt);
 
 /** @fn calculate
  *  Determines a sun vector given the current voltage readings. If an accurate
@@ -50,8 +50,9 @@ extern void update_sensors(float adc_flt);
  *  return FAILURE instead of COMPLETE.
  *  @param[out] sun_vec Normalized vector in R3 is written to this reference.
  *  @return Sun sensor resulting mode - i.e. COMPLETE or FAILURE. */
-extern unsigned char calculate_sun_vector(lin::Vector3f &sun_vec);
+unsigned char calculate_sun_vector(lin::Vector3f &sun_vec);
 
 }  // namespace ssa
+}  // namespace adcs
 
 #endif

--- a/src/adcs/ssa_config.hpp
+++ b/src/adcs/ssa_config.hpp
@@ -1,6 +1,6 @@
 //
-// include/ssa/ssa_config.hpp
-// ADCS
+// src/adcs/ssa_config.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol         kpk63@cornell.edu
@@ -13,43 +13,45 @@
 // TODO : Fill in the normal vector matrices
 // TODO : Consider moving this definition to the psim repository
 
-#ifndef PAN_ADCS_INCLUDE_SSA_CONFIG_HPP_
-#define PAN_ADCS_INCLUDE_SSA_CONFIG_HPP_
+#ifndef SRC_ADCS_SSA_CONFIG_HPP_
+#define SRC_ADCS_SSA_CONFIG_HPP_
 
-#include <ADS1015.hpp>
+#include "dev/ADS1015.hpp"
+
 #include <i2c_t3.h>
 #include <lin.hpp>
 
+namespace adcs {
 namespace ssa {
 
 /** Wire for the face two ADC. */
 static i2c_t3 *const adc2_wire = &Wire1;
 /** Address for the zeroth ADC. */
-static unsigned char const adc2_addr = ADS1015::ADDR::SSDA;
+static unsigned char const adc2_addr = dev::ADS1015::ADDR::SSDA;
 /** Alert pin for the zeroth ADC. */
 static unsigned int const adc2_alrt = 13;
 /** Wire for the face three ADC. */
 static i2c_t3 *const adc3_wire = &Wire2;
 /** Address for the face three ADC. */
-static unsigned char const adc3_addr = ADS1015::ADDR::GND;
+static unsigned char const adc3_addr = dev::ADS1015::ADDR::GND;
 /** Alert pin for the face three ADC. */
 static unsigned int const adc3_alrt = 15;
 /** Wire for the face four ADC. */
 static i2c_t3 *const adc4_wire = &Wire2;
 /** Address for the face four ADC. */
-static unsigned char const adc4_addr = ADS1015::ADDR::VDD;
+static unsigned char const adc4_addr = dev::ADS1015::ADDR::VDD;
 /** Alert pin for the face four ADC. */
 static unsigned int const adc4_alrt = 20;
 /** Wire for the face five ADC. */
 static i2c_t3 *const adc5_wire = &Wire2;
 /** Address for the face five ADC. */
-static unsigned char const adc5_addr = ADS1015::ADDR::SSDA;
+static unsigned char const adc5_addr = dev::ADS1015::ADDR::SSDA;
 /** Alert pin for the face five ADC. */
 static unsigned int const adc5_alrt = 27;
 /** Wire for the face six ADC. */
 static i2c_t3 *const adc6_wire = &Wire2;
 /** Address for the face six ADC. */
-static unsigned char const adc6_addr = ADS1015::ADDR::SSCL;
+static unsigned char const adc6_addr = dev::ADS1015::ADDR::SSCL;
 /** Alert pin for the six five ADC. */
 static unsigned int const adc6_alrt = 28;
 /** Timeout in microseconds for the ADCs. */
@@ -125,5 +127,6 @@ static_assert(false, "Must define PAN_LEADER or PAN_FOLLOWER");
 #endif
 });
 }  // namespace ssa
+}  // namespace adcs
 
 #endif

--- a/src/adcs/state.cpp
+++ b/src/adcs/state.cpp
@@ -1,6 +1,6 @@
 //
-// src/state.cpp
-// ADCS
+// src/adcs/state.cpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -10,7 +10,9 @@
 // Cornell Univeristy
 //
 
-#include <adcs/state.hpp>
+#include "state.hpp"
+
+namespace adcs {
 
 struct Registers volatile registers = {
   0x0F, // Who am I
@@ -65,3 +67,4 @@ struct Registers volatile registers = {
     0, // Cmd flag
   }
 };
+}  // namespace adcs

--- a/src/adcs/state.hpp
+++ b/src/adcs/state.hpp
@@ -1,6 +1,6 @@
 //
-// include/state.hpp
-// ADCS
+// src/adcs/state.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -13,8 +13,10 @@
 // TODO : Initialize the PID controller values for the gyroscope heater
 // TODO : Complete HAVT array
 
-#ifndef PAN_ADCS_INCLUDE_STATE_HPP_
-#define PAN_ADCS_INCLUDE_STATE_HPP_
+#ifndef SRC_ADCS_STATE_HPP_
+#define SRC_ADCS_STATE_HPP_
+
+namespace adcs {
 
 /** \struct ReactionWheelRegisters
  *  State data structure for the reaction wheel assembly. All commands and reads
@@ -144,5 +146,7 @@ struct Registers {
 /** Overall state struct for the ADCS system. This struct will be edited by both
  *  the i2c interupt service routines and the main thread processes. */
 extern struct Registers volatile registers;
+
+}  // namespace adcs
 
 #endif

--- a/src/adcs/state_controller.cpp
+++ b/src/adcs/state_controller.cpp
@@ -1,9 +1,10 @@
 //
-// src/state_controller.cpp
-// ADCS
+// src/adcs/state_controller.cpp
+// FlightSoftware
 //
 // Contributors:
-//   Kyle Krol  kpk63@cornell.edu
+//   Kyle Krol   kpk63@cornell.edu
+//   Shihao Cao  sfc72@cornell.edu
 //
 // Pathfinder for Autonomous Navigation
 // Space Systems Design Studio
@@ -16,16 +17,16 @@
 #define DEBUG
 #endif
 
-#include <adcs_constants.hpp>
-#include <adcs_registers.hpp>
-
-#include <adcs/state.hpp>
-#include <adcs/state_controller.hpp>
-#include <adcs/utl/convert.hpp>
-#include <adcs/utl/debug.hpp>
+#include "constants.hpp"
+#include "state.hpp"
+#include "state_controller.hpp"
+#include "state_registers.hpp"
+#include "utl/convert.hpp"
+#include "utl/debug.hpp"
 
 #include <bitset>
 
+namespace adcs {
 namespace umb {
 
 /** \fn endian_write
@@ -278,8 +279,8 @@ void on_i2c_recieve(unsigned int bytes) {
       if (umb::wire->available() < 1) break;
       registers.havt.cmd_table = endian_read<unsigned int>();
       registers.havt.cmd_flg = CMDFlag::UPDATED;
-            
-      #ifdef UMB_DEBUG
+
+      #ifdef DEBUG
       std::bitset<havt::max_devices>temp(registers.havt.cmd_table);
 
       //note 32 = havt::max_devices for clarity
@@ -406,9 +407,9 @@ void on_i2c_request() {
     case Register::HAVT_READ: {
       //table is stored as an unsigned int, so merely write out to i2c
       endian_write(registers.havt.read_table);
-      std::bitset<havt::max_devices> temp_bitset(registers.havt.read_table);
 
       #ifdef DEBUG
+      std::bitset<havt::max_devices> temp_bitset(registers.havt.read_table);
 
       //note 32 = havt::max_devices for clarity
       char buffer[33];
@@ -423,7 +424,6 @@ void on_i2c_request() {
       // You should see the below if nothing is connected, MTRs and WHEELS OK
       // REMEMBER DEVICE INDEX STEPS UP FROM RIGHT TO LEFT
       // Read Internal Table As: 00000000000000000000001110111000
-
       #endif
       break;
     }
@@ -434,3 +434,4 @@ void on_i2c_request() {
   }
 }
 }  // namespace umb
+}  // namespace adcs

--- a/src/adcs/state_controller.hpp
+++ b/src/adcs/state_controller.hpp
@@ -1,6 +1,6 @@
 //
-// include/state_controller.hpp
-// ADCS
+// src/adcs/state_controller.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -10,11 +10,12 @@
 // Cornell Univeristy
 //
 
-#ifndef PAN_ADCS_INCLUDE_STATE_CONTROLLER_HPP_
-#define PAN_ADCS_INCLUDE_STATE_CONTROLLER_HPP_
+#ifndef SRC_ADCS_STATE_CONTROLLER_HPP_
+#define SRC_ADCS_STATE_CONTROLLER_HPP_
 
 #include <i2c_t3.h>
 
+namespace adcs {
 namespace umb {
 
 /** Wire used to communicate with the umbilical board. */
@@ -22,12 +23,13 @@ static i2c_t3 *const wire = &Wire;
 
 /** \fn on_i2c_recieve
  *  i2c message recieved callback to handle data pushes to the state struct. */
-extern void on_i2c_recieve(unsigned int bytes);
+void on_i2c_recieve(unsigned int bytes);
 
 /** \fn on_i2c_request
  *  i2c message requested callback to handl data pulls from the state struct. */
-extern void on_i2c_request();
+void on_i2c_request();
 
 }  // namespace umb
+}  // namespace adcs
 
 #endif

--- a/src/adcs/state_registers.hpp
+++ b/src/adcs/state_registers.hpp
@@ -1,0 +1,58 @@
+//
+// src/adcs/state_registers.hpp
+// FlightSoftware
+//
+// Contributors:
+//   Kyle Krol  kpk63@cornell.edu
+//
+// Pathfinder for Autonomous Navigation
+// Space Systems Design Studio
+// Cornell Univeristy
+//
+
+#ifndef SRC_ADCS_STATE_REGISTERS_HPP_
+#define SRC_ADCS_STATE_REGISTERS_HPP_
+
+namespace adcs {
+
+/** @enum Register
+ *  Enumerates the 'addresses' of the registers defined in the Registers struct.
+ *  The below value should be the first and  */
+enum Register : unsigned char {
+  WHO_AM_I,
+  ENDIANNESS,
+  ADCS_MODE,
+  READ_POINTER,
+  RWA_MODE,
+  RWA_COMMAND,
+  RWA_COMMAND_FLAG,
+  RWA_SPEED_FILTER,
+  RWA_RAMP_FILTER,
+  RWA_SPEED_RD,
+  RWA_RAMP_READ,
+  MTR_MODE,
+  MTR_COMMAND,
+  MTR_LIMIT,
+  MTR_COMMAND_FLAG,
+  SSA_MODE,
+  SSA_SUN_VECTOR,
+  SSA_VOLTAGE_FILTER,
+  SSA_VOLTAGE_READ,
+  SSA_VOLTAGE_THRESHOLD,
+  IMU_MODE,
+  IMU_MAG_READ,
+  IMU_GYR_READ,
+  IMU_GYR_TEMP_READ,
+  IMU_MAG_FILTER,
+  IMU_GYR_FILTER,
+  IMU_GYR_TEMP_FILTER,
+  IMU_GYR_TEMP_KP,
+  IMU_GYR_TEMP_KI,
+  IMU_GYR_TEMP_KD,
+  IMU_GYR_TEMP_DESIRED,
+  HAVT_COMMAND,
+  HAVT_READ
+};
+}  // namespace adcs
+
+#endif

--- a/src/adcs/utl/convert.hpp
+++ b/src/adcs/utl/convert.hpp
@@ -1,6 +1,6 @@
 //
-// include/utl/convert.hpp
-// ADCS
+// src/adcs/utl/convert.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -10,9 +10,10 @@
 // Cornell Univeristy
 //
 
-#ifndef PAN_ADCS_UTL_CONVERT_HPP_
-#define PAN_ADCS_UTL_CONVERT_HPP_
+#ifndef SRC_ADCS_UTL_CONVERT_HPP_
+#define SRC_ADCS_UTL_CONVERT_HPP_
 
+namespace adcs {
 namespace utl {
 
 /** Converts a signed char to a floating point value. */
@@ -40,6 +41,7 @@ inline unsigned short us(float f, float min, float max);
 inline signed short ss(float f, float min, float max);
 
 }  // namespace utl
+}  // namespace adcs
 
 #include "convert.inl"
 

--- a/src/adcs/utl/convert.inl
+++ b/src/adcs/utl/convert.inl
@@ -1,6 +1,6 @@
 //
-// include/utl/inl/convert.inl
-// ADCS
+// src/adcs/utl/convert.inl
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -12,6 +12,7 @@
 
 #include "convert.hpp"
 
+namespace adcs {
 namespace utl {
 
 inline float fp(signed char si, float min, float max) {
@@ -46,3 +47,4 @@ inline signed short ss(float f, float min, float max) {
   return (signed short)(65535.0f * (f - min) / (max - min) - 32768.0f);
 }
 }  // namespace utl
+}  // namespace adcs

--- a/src/adcs/utl/debug.hpp
+++ b/src/adcs/utl/debug.hpp
@@ -1,6 +1,6 @@
 //
-// include/debug.hpp
-// ADCS
+// src/adcs/utl/debug.hpp
+// FlightSoftware
 //
 // Contributors:
 //   Kyle Krol  kpk63@cornell.edu
@@ -10,8 +10,8 @@
 // Cornell Univeristy
 //
 
-#ifndef PAN_ADCS_INCLUDE_DEBUG_HPP_
-#define PAN_ADCS_INCLUDE_DEBUG_HPP_
+#ifndef SRC_ADCS_UTL_DEBUG_HPP_
+#define SRC_ADCS_UTL_DEBUG_HPP_
 
 #include <Arduino.h>
 


### PR DESCRIPTION
I've migrated all the ADCS drivers into the source folder and refactored the ADCS code accordingly. I've also duplicated the ADCS files that were present in common software.

@shihaocao If you could pay close attention to the HAVT changes (shouldn't be any huge changes) that be great. Also, once this is merged, it'd be awesome if we could migreate FSW ADCS code to use the headers in `src/adcs/**` and not common software (we can remove ADCS code from common software then)!

Most of the changes are updates to file comments, include guards, and removing the `extern` keyword from some of the function interfaces.

It may be easier to check the branch out locally and poke around.