### PR TITLE
Fault Update

### DIFF
--- a/src/fsw/FCCode/Fault.cpp
+++ b/src/fsw/FCCode/Fault.cpp
@@ -10,7 +10,7 @@ Fault::Fault(const std::string& name,
     override_f(name + ".override", fault_bool_sr),
     unsignal_f(name + ".unsignal", fault_bool_sr),
     // 65536 = 2^16 -1
-    persist_sr(0, 65535, 16),
+    persist_sr(65535),
     persistence_f(name + ".persistence", persist_sr)
 {
   set(default_setting);

--- a/src/fsw/FCCode/Fault.cpp
+++ b/src/fsw/FCCode/Fault.cpp
@@ -25,7 +25,6 @@ bool Fault::add_to_registry(StateFieldRegistry& r) {
     if (!r.add_writable_field(static_cast<WritableStateFieldBase*>(&suppress_f))) return false;
     if (!r.add_writable_field(static_cast<WritableStateFieldBase*>(&override_f))) return false;
     if (!r.add_writable_field(static_cast<WritableStateFieldBase*>(&unsignal_f))) return false;
-    if (!r.add_writable_field(static_cast<WritableStateFieldBase*>(&signal_f))) return false;
     return true;
 }
 

--- a/src/fsw/FCCode/Fault.cpp
+++ b/src/fsw/FCCode/Fault.cpp
@@ -24,6 +24,7 @@ bool Fault::add_to_registry(StateFieldRegistry& r) {
     if (!r.add_writable_field(static_cast<WritableStateFieldBase*>(&suppress_f))) return false;
     if (!r.add_writable_field(static_cast<WritableStateFieldBase*>(&override_f))) return false;
     if (!r.add_writable_field(static_cast<WritableStateFieldBase*>(&unsignal_f))) return false;
+    if (!r.add_writable_field(static_cast<WritableStateFieldBase*>(&persistence_f))) return false;
     return true;
 }
 

--- a/src/fsw/FCCode/Fault.cpp
+++ b/src/fsw/FCCode/Fault.cpp
@@ -22,7 +22,7 @@ bool Fault::add_to_registry(StateFieldRegistry& r) {
 }
 
 void Fault::signal() {
-    consider_pulls();
+    process_commands();
 
     if (cc > static_cast<unsigned int>(last_fault_time) || cc == 0) {
         num_consecutive_faults++;
@@ -35,7 +35,7 @@ void Fault::signal() {
 }
 
 void Fault::unsignal() {
-    consider_pulls();
+    process_commands();
     set(false);
     num_consecutive_faults = 0;
 }
@@ -52,8 +52,7 @@ bool Fault::is_faulted() const {
     else return get();
 }
 
-void Fault::consider_pulls(){
-    // suppress_f was set to true from ground
+void Fault::process_commands(){
     if(prev_override == false && override_f.get()){
         num_consecutive_faults = 0;
     }
@@ -62,4 +61,14 @@ void Fault::consider_pulls(){
     }
     prev_override = override_f.get();
     prev_suppress = suppress_f.get();
+
+    if(signal_f.get()){
+        signal_f.set(false);
+        // TODO: should this just be set(true)?
+        signal();
+    }
+    if(unsignal_f.get()){
+        unsignal_f.set(false);
+        unsignal();
+    }
 }

--- a/src/fsw/FCCode/Fault.cpp
+++ b/src/fsw/FCCode/Fault.cpp
@@ -21,35 +21,35 @@ bool Fault::add_to_registry(StateFieldRegistry& r) {
     if (!r.add_writable_field(static_cast<WritableStateFieldBase*>(this))) return false;
     if (!r.add_writable_field(static_cast<WritableStateFieldBase*>(&suppress_f))) return false;
     if (!r.add_writable_field(static_cast<WritableStateFieldBase*>(&override_f))) return false;
+    if (!r.add_writable_field(static_cast<WritableStateFieldBase*>(&unsignal_f))) return false;
+    if (!r.add_writable_field(static_cast<WritableStateFieldBase*>(&signal_f))) return false;
     return true;
 }
 
 void Fault::signal() {
-    process_commands();
-
     if (cc > static_cast<unsigned int>(last_fault_time) || cc == 0) {
-        num_consecutive_faults++;
+        num_consecutive_signals++;
         last_fault_time = cc;
     }
 
-    if (num_consecutive_faults > persistence) {
+    if (num_consecutive_signals > persistence) {
         set(true);
     }
+
+    process_commands();
 }
 
 void Fault::unsignal() {
-    process_commands();
     set(false);
-    num_consecutive_faults = 0;
+    num_consecutive_signals = 0;
+    process_commands();
 }
 
 bool Fault::is_faulted() const {
     if (override_f.get()) {
-        num_consecutive_faults = 0;
         return true;
     }
     else if (suppress_f.get()) {
-        num_consecutive_faults = 0;
         return false;
     }
     else return get();
@@ -57,21 +57,27 @@ bool Fault::is_faulted() const {
 
 void Fault::process_commands(){
     if(prev_override == false && override_f.get()){
-        num_consecutive_faults = 0;
+        num_consecutive_signals = 0;
     }
     if(prev_suppress == false && suppress_f.get()){
-        num_consecutive_faults = 0;
+        num_consecutive_signals = 0;
     }
     prev_override = override_f.get();
     prev_suppress = suppress_f.get();
 
     if(signal_f.get()){
         signal_f.set(false);
-        // TODO: should this just be set(true)?
-        signal();
+        // TODO: can also just be signal()
+        set(true);
     }
     if(unsignal_f.get()){
         unsignal_f.set(false);
         unsignal();
     }
 }
+
+#ifdef UNIT_TEST
+unsigned int Fault::get_num_consecutive_signals(){
+    return num_consecutive_signals;
+}
+#endif

--- a/src/fsw/FCCode/Fault.cpp
+++ b/src/fsw/FCCode/Fault.cpp
@@ -6,8 +6,11 @@ Fault::Fault(const std::string& name,
     WritableStateField<bool>(name, Serializer<bool>()),
     cc(control_cycle_count),
     persistence(_persistence),
-    suppress_f(name + ".suppress", Serializer<bool>()),
-    override_f(name + ".override", Serializer<bool>())
+    fault_bool_sr(),
+    suppress_f(name + ".suppress", fault_bool_sr),
+    override_f(name + ".override", fault_bool_sr),
+    unsignal_f(name + ".unsignal", fault_bool_sr),
+    signal_f(name + ".signal", fault_bool_sr)
 {
   set(default_setting);
   override_f.set(false);

--- a/src/fsw/FCCode/Fault.cpp
+++ b/src/fsw/FCCode/Fault.cpp
@@ -22,6 +22,8 @@ bool Fault::add_to_registry(StateFieldRegistry& r) {
 }
 
 void Fault::signal() {
+    consider_pulls();
+
     if (cc > static_cast<unsigned int>(last_fault_time) || cc == 0) {
         num_consecutive_faults++;
         last_fault_time = cc;
@@ -33,6 +35,7 @@ void Fault::signal() {
 }
 
 void Fault::unsignal() {
+    consider_pulls();
     set(false);
     num_consecutive_faults = 0;
 }
@@ -47,4 +50,16 @@ bool Fault::is_faulted() const {
         return false;
     }
     else return get();
+}
+
+void Fault::consider_pulls(){
+    // suppress_f was set to true from ground
+    if(prev_override == false && override_f.get()){
+        num_consecutive_faults = 0;
+    }
+    if(prev_suppress == false && suppress_f.get()){
+        num_consecutive_faults = 0;
+    }
+    prev_override = override_f.get();
+    prev_suppress = suppress_f.get();
 }

--- a/src/fsw/FCCode/Fault.hpp
+++ b/src/fsw/FCCode/Fault.hpp
@@ -54,11 +54,14 @@ class Fault : public WritableStateField<bool> {
     unsigned int get_num_consecutive_signals();
     #endif
   private:
+    #ifndef UNIT_TEST // Don't compile this for UNIT_TESTs to simulate a ground commanded one time trigger
+
     // Make the get() and set() methods of the state field private,
     // so that the user is forced to use the signal() and unsignal()
     // methods instead.
     using WritableStateField<bool>::set;
     using WritableStateField<bool>::get;
+    #endif
 
     unsigned int& cc; // Control cycle count
     unsigned int last_fault_time = 0; // Last control cycle # that the fault condition

--- a/src/fsw/FCCode/Fault.hpp
+++ b/src/fsw/FCCode/Fault.hpp
@@ -59,18 +59,25 @@ class Fault : public WritableStateField<bool> {
     unsigned int persistence; // Persistence threshold for fault signal
     mutable unsigned int num_consecutive_faults = 0; // Number of consecutive fault condition
                                                      // occurrences at the current moment.
-
+    
+    // Keeps track of the previous suppress or override state
     bool prev_suppress = false;
     bool prev_override = false;
 
     /**
-     * @brief State fields that can be set by the ground to suppress
-     * or forcibly signal the fault.
+     * @brief State fields that can be set by the ground to
+     * suppress, override, signal and unsignal the fault
      */
     WritableStateField<bool> suppress_f;
     WritableStateField<bool> override_f;
+    WritableStateField<bool> signal_f;
+    WritableStateField<bool> unsignal_f;
 
-    void consider_pulls();
+    /**
+     * @brief Resets consecutive faults to 0, whenever pulls transition from false to true
+     * Also calls signal() or unsignal() if signal_f or unsignal_f are true respectively
+     */
+    void process_commands();
 };
 
 #endif

--- a/src/fsw/FCCode/Fault.hpp
+++ b/src/fsw/FCCode/Fault.hpp
@@ -22,24 +22,23 @@ class Fault : public WritableStateField<bool> {
 
     /**
      * @brief Client-facing function to signal an occurrence of the
-     * fault-related condition.
+     * fault-related condition. Attempts to increment num_consecutive_signals by 1
      */
     void signal();
 
     /**
      * @brief Client-facing function to signal a non-occurrence of the
-     * fault-related condition. Resets the persistence of the fault.
+     * fault-related condition. Resets the num_consecutive_signals to 0
      */
     void unsignal();
 
     /**
-     * @brief If the fault-related condition has been persistent or if
-     * the fault is overridden by the ground, the fault is signaled.
-     * Otherwise, if the fault-related condition has not been persistent,
-     * or if the fault is suppressed by the ground, the fault is not signaled.
+     * @brief Calls process_commands, sets the fault true if num_consecutive_faults > persistence_f
+     * returns true or false if override or suppress are true respectivly,
+     * Otherwise, it returns the state of the fault itself.
      *
-     * @return true 
-     * @return false 
+     * @return true if: override is true, or num_consecutive_faults > persistence_f
+     * @return false if: suppress is true, or num_consecutive_faults < persistence_f 
      */
     bool is_faulted();
 
@@ -82,8 +81,8 @@ class Fault : public WritableStateField<bool> {
     WritableStateField<unsigned int> persistence_f;
 
     /**
-     * @brief Resets consecutive faults to 0, whenever pulls transition from false to true
-     * Also calls signal() or unsignal() if signal_f or unsignal_f are true respectively
+     * @brief Resets consecutive faults to 0, whenever pulls transition from false to true,
+     * or if unsignal_f is true.
      */
     void process_commands();
 };

--- a/src/fsw/FCCode/Fault.hpp
+++ b/src/fsw/FCCode/Fault.hpp
@@ -68,10 +68,11 @@ class Fault : public WritableStateField<bool> {
      * @brief State fields that can be set by the ground to
      * suppress, override, signal and unsignal the fault
      */
+    Serializer<bool> fault_bool_sr;
     WritableStateField<bool> suppress_f;
     WritableStateField<bool> override_f;
-    WritableStateField<bool> signal_f;
     WritableStateField<bool> unsignal_f;
+    WritableStateField<bool> signal_f;
 
     /**
      * @brief Resets consecutive faults to 0, whenever pulls transition from false to true

--- a/src/fsw/FCCode/Fault.hpp
+++ b/src/fsw/FCCode/Fault.hpp
@@ -45,6 +45,14 @@ class Fault : public WritableStateField<bool> {
      */
     bool is_faulted() const;
 
+    #ifdef UNIT_TEST
+    /**
+     * @brief a debug return that tells the current consecutive signals
+     * 
+     * @return unsigned int 
+     */
+    unsigned int get_num_consecutive_signals();
+    #endif
   private:
     // Make the get() and set() methods of the state field private,
     // so that the user is forced to use the signal() and unsignal()
@@ -57,7 +65,7 @@ class Fault : public WritableStateField<bool> {
                                       // occurred
 
     unsigned int persistence; // Persistence threshold for fault signal
-    mutable unsigned int num_consecutive_faults = 0; // Number of consecutive fault condition
+    mutable unsigned int num_consecutive_signals = 0; // Number of consecutive signal condition
                                                      // occurrences at the current moment.
     
     // Keeps track of the previous suppress or override state

--- a/src/fsw/FCCode/Fault.hpp
+++ b/src/fsw/FCCode/Fault.hpp
@@ -11,11 +11,9 @@ class Fault : public WritableStateField<bool> {
      * @param name Name of base fault state field.
      * @param _persistence Persistence threshold before signaling fault.
      * @param control_cycle_count Reference to the control cycle count.
-     * @param default_setting Default setting of fault signal.
      */
     Fault(const std::string& name,
-          const size_t _persistence, unsigned int& control_cycle_count,
-          const bool default_setting = false);
+          const size_t _persistence, unsigned int& control_cycle_count);
 
     /**
      * @brief Add fault-related flags to the registry.
@@ -43,7 +41,7 @@ class Fault : public WritableStateField<bool> {
      * @return true 
      * @return false 
      */
-    bool is_faulted() const;
+    bool is_faulted();
 
     #ifdef UNIT_TEST
     /**
@@ -54,14 +52,11 @@ class Fault : public WritableStateField<bool> {
     unsigned int get_num_consecutive_signals();
     #endif
   private:
-    #ifndef UNIT_TEST // Don't compile this for UNIT_TESTs to simulate a ground commanded one time trigger
-
     // Make the get() and set() methods of the state field private,
     // so that the user is forced to use the signal() and unsignal()
     // methods instead.
     using WritableStateField<bool>::set;
     using WritableStateField<bool>::get;
-    #endif
 
     unsigned int& cc; // Control cycle count
     unsigned int last_fault_time = 0; // Last control cycle # that the fault condition

--- a/src/fsw/FCCode/Fault.hpp
+++ b/src/fsw/FCCode/Fault.hpp
@@ -64,7 +64,6 @@ class Fault : public WritableStateField<bool> {
     unsigned int last_fault_time = 0; // Last control cycle # that the fault condition
                                       // occurred
 
-    unsigned int persistence; // Persistence threshold for fault signal
     mutable unsigned int num_consecutive_signals = 0; // Number of consecutive signal condition
                                                      // occurrences at the current moment.
     
@@ -80,7 +79,9 @@ class Fault : public WritableStateField<bool> {
     WritableStateField<bool> suppress_f;
     WritableStateField<bool> override_f;
     WritableStateField<bool> unsignal_f;
-    WritableStateField<bool> signal_f;
+
+    Serializer<unsigned int> persist_sr;
+    WritableStateField<unsigned int> persistence_f;
 
     /**
      * @brief Resets consecutive faults to 0, whenever pulls transition from false to true

--- a/src/fsw/FCCode/Fault.hpp
+++ b/src/fsw/FCCode/Fault.hpp
@@ -60,12 +60,17 @@ class Fault : public WritableStateField<bool> {
     mutable unsigned int num_consecutive_faults = 0; // Number of consecutive fault condition
                                                      // occurrences at the current moment.
 
+    bool prev_suppress = false;
+    bool prev_override = false;
+
     /**
      * @brief State fields that can be set by the ground to suppress
      * or forcibly signal the fault.
      */
     WritableStateField<bool> suppress_f;
     WritableStateField<bool> override_f;
+
+    void consider_pulls();
 };
 
 #endif

--- a/test/test_fsw_fault/test_fsw_fault.cpp
+++ b/test/test_fsw_fault/test_fsw_fault.cpp
@@ -214,6 +214,7 @@ void test_dynamic_persistence(){
     TEST_ASSERT_EQUAL(6, fault_fp->get_num_consecutive_signals());
 
     // edit persistence to lower it below current num_consecutive_signals
+    // instantly triggers due to previous accumulation
     control_cycle_count++; fault.signal(); persistence_fp->set(5);
     TEST_ASSERT_TRUE(fault_fp->is_faulted());
     TEST_ASSERT_EQUAL(7, fault_fp->get_num_consecutive_signals());

--- a/test/test_fsw_fault/test_fsw_fault.cpp
+++ b/test/test_fsw_fault/test_fsw_fault.cpp
@@ -111,9 +111,8 @@ void test_process_commands(){
     TEST_ASSERT_EQUAL(2, fault_fp->get_num_consecutive_signals());
     TEST_ASSERT_FALSE(fault_fp->is_faulted());
 
+    // commanding an override modifies return of is_faulted in the current cycle
     control_cycle_count++; fault.signal(); override_fp->set(true);
-    // is_faulted should be true since override_fp modifies the return of is_faulted, 
-    // remember, commands processed during signal() or unsignal()
     TEST_ASSERT_TRUE(fault_fp->is_faulted());
     TEST_ASSERT_EQUAL(3, fault_fp->get_num_consecutive_signals());
 
@@ -157,17 +156,6 @@ void test_process_commands(){
     TEST_ASSERT_TRUE(fault_fp->is_faulted());
 
     // Return to normal operation, signaling condition is not met
-    control_cycle_count++; fault.unsignal();
-    TEST_ASSERT_EQUAL(0, fault_fp->get_num_consecutive_signals());
-    TEST_ASSERT_FALSE(fault_fp->is_faulted());
-
-    // Command a trigger of the fault (will only last for 1 cycle),
-    // applied on current cycle
-    control_cycle_count++; fault.unsignal(); fault_fp->set(true); // simulated ground trigger command
-    TEST_ASSERT_EQUAL(0, fault_fp->get_num_consecutive_signals());
-    TEST_ASSERT_TRUE(fault_fp->is_faulted());
-
-    // the next cycle, fault is released
     control_cycle_count++; fault.unsignal();
     TEST_ASSERT_EQUAL(0, fault_fp->get_num_consecutive_signals());
     TEST_ASSERT_FALSE(fault_fp->is_faulted());

--- a/test/test_fsw_fault/test_fsw_fault.cpp
+++ b/test/test_fsw_fault/test_fsw_fault.cpp
@@ -228,6 +228,7 @@ void setup() {
     UNITY_BEGIN();
     RUN_TEST(test_fault_normal_behavior);
     RUN_TEST(test_fault_overridden_behavior);
+    RUN_TEST(test_process_commands);
     UNITY_END();
 }
 

--- a/test/test_fsw_fault/test_fsw_fault.cpp
+++ b/test/test_fsw_fault/test_fsw_fault.cpp
@@ -11,9 +11,7 @@ void test_fault_normal_behavior() {
 
     // Test constructors
     Fault fault("fault", 5, control_cycle_count);
-    TEST_ASSERT_FALSE(fault_fp->is_faulted());
-    Fault fault2("fault", 5, control_cycle_count, true);
-    TEST_ASSERT(fault2.is_faulted());
+    Fault fault2("fault2", 5, control_cycle_count, true);
 
     // Test that adding the fault to the registry works
     StateFieldRegistry r;
@@ -21,6 +19,15 @@ void test_fault_normal_behavior() {
     TEST_ASSERT(r.find_readable_field("fault"));
     TEST_ASSERT(r.find_writable_field("fault.override"));
     TEST_ASSERT(r.find_writable_field("fault.suppress"));
+    TEST_ASSERT(r.find_readable_field("fault2"));
+    TEST_ASSERT(r.find_writable_field("fault2.override"));
+    TEST_ASSERT(r.find_writable_field("fault2.suppress"));
+
+    Fault* fault_fp = static_cast<Fault*>(r.find_writable_field("fault"));
+    Fault* fault2_fp = static_cast<Fault*>(r.find_writable_field("fault2"));
+
+    TEST_ASSERT_FALSE(fault_fp->is_faulted());
+    TEST_ASSERT(fault2_fp->is_faulted());
 
     // Fault should not be signaled when signal condition happens under the persistence
     for(int i = 0; i < 4; i++) {

--- a/test/test_fsw_fault/test_fsw_fault.cpp
+++ b/test/test_fsw_fault/test_fsw_fault.cpp
@@ -19,7 +19,6 @@ void test_fault_normal_behavior() {
     TEST_ASSERT(r.find_readable_field("fault"));
     TEST_ASSERT(r.find_writable_field("fault.override"));
     TEST_ASSERT(r.find_writable_field("fault.suppress"));
-    TEST_ASSERT(r.find_writable_field("fault.signal"));
     TEST_ASSERT(r.find_writable_field("fault.unsignal"));
 
     fault2.add_to_registry(r);
@@ -105,7 +104,6 @@ void test_process_commands(){
     Fault* fault_fp = static_cast<Fault*>(r.find_writable_field_t<bool>("fault"));
     WritableStateField<bool>* override_fp = r.find_writable_field_t<bool>("fault.override");
     WritableStateField<bool>* suppress_fp = r.find_writable_field_t<bool>("fault.suppress");
-    WritableStateField<bool>* signal_fp = r.find_writable_field_t<bool>("fault.signal");
     WritableStateField<bool>* unsignal_fp = r.find_writable_field_t<bool>("fault.unsignal");
 
     control_cycle_count++; fault.signal();
@@ -165,13 +163,8 @@ void test_process_commands(){
     TEST_ASSERT_FALSE(fault_fp->is_faulted());
 
     // Command a trigger of the fault (will only last for 1 cycle),
-    // but only applied on the next cycle
-    control_cycle_count++; fault.unsignal(); signal_fp->set(true);
-    TEST_ASSERT_EQUAL(0, fault_fp->get_num_consecutive_signals());
-    TEST_ASSERT_FALSE(fault_fp->is_faulted());
-
-    // application of signal_fp triggers the fault
-    control_cycle_count++; fault.unsignal();
+    // applied on current cycle
+    control_cycle_count++; fault.unsignal(); fault_fp->set(true); // simulated ground trigger command
     TEST_ASSERT_EQUAL(0, fault_fp->get_num_consecutive_signals());
     TEST_ASSERT_TRUE(fault_fp->is_faulted());
 

--- a/test/test_fsw_fault/test_fsw_fault.cpp
+++ b/test/test_fsw_fault/test_fsw_fault.cpp
@@ -16,7 +16,7 @@ void test_fault_normal_behavior() {
     // Test that adding the fault to the registry works
     StateFieldRegistry r;
     TEST_ASSERT(fault.add_to_registry(r));
-    TEST_ASSERT(r.find_readable_field("fault"));
+    TEST_ASSERT(r.find_writable_field("fault"));
     TEST_ASSERT(r.find_writable_field("fault.override"));
     TEST_ASSERT(r.find_writable_field("fault.suppress"));
     TEST_ASSERT(r.find_writable_field("fault.unsignal"));

--- a/test/test_fsw_fault/test_fsw_fault.cpp
+++ b/test/test_fsw_fault/test_fsw_fault.cpp
@@ -113,7 +113,6 @@ void test_process_commands(){
 
     control_cycle_count++; fault.signal(); override_fp->set(true);
     // is_faulted should be true since override_fp modifies the return of is_faulted, 
-    // but num_consecutive is not yet 0
     // remember, commands processed during signal() or unsignal()
     TEST_ASSERT_TRUE(fault_fp->is_faulted());
     TEST_ASSERT_EQUAL(3, fault_fp->get_num_consecutive_signals());
@@ -223,7 +222,7 @@ void test_dynamic_persistence(){
     TEST_ASSERT_EQUAL(0, fault_fp->get_num_consecutive_signals());
     TEST_ASSERT_FALSE(fault_fp->is_faulted());
 
-    // nominal satellite operation, and a command to change persistence to 3
+    // nominal satellite operation, and a command to change persistence to 1
     control_cycle_count++; fault.unsignal(); persistence_fp->set(1);
     TEST_ASSERT_EQUAL(0, fault_fp->get_num_consecutive_signals());
     TEST_ASSERT_FALSE(fault_fp->is_faulted());
@@ -234,6 +233,7 @@ void test_dynamic_persistence(){
     TEST_ASSERT_EQUAL(2, fault_fp->get_num_consecutive_signals());
     TEST_ASSERT_TRUE(fault_fp->is_faulted());
 
+    // command an increase in persistence
     control_cycle_count++; fault.signal(); 
     control_cycle_count++; fault.signal();
     control_cycle_count++; fault.signal();
@@ -241,7 +241,7 @@ void test_dynamic_persistence(){
     TEST_ASSERT_EQUAL(6, fault_fp->get_num_consecutive_signals());
     TEST_ASSERT_TRUE(fault_fp->is_faulted());
 
-    // if signals <= persistence, fault is released
+    // since signals <= persistence, fault is released
     control_cycle_count++; fault.signal();
     TEST_ASSERT_EQUAL(7, fault_fp->get_num_consecutive_signals());
     TEST_ASSERT_FALSE(fault_fp->is_faulted());


### PR DESCRIPTION
This upgrades the fault class and adds more naunced behavior.

There are now two more additional bool statefields. `signal_f` and `unsignal_f`. If these are set to true from the ground, the fault will be faulted or unfaulted for one cycle only, regardless of whether or not a `signal()` or `unsignal()` condition was met.

Further if the `override_f` or `suppress_f` statefields are set to true (from false), the Fault will reset its `num_consecutive_signals` to `0`.