### PR TITLE
Added better control task tests

### DIFF
--- a/src/fsw/FCCode/ControlTask.hpp
+++ b/src/fsw/FCCode/ControlTask.hpp
@@ -47,6 +47,7 @@ class ControlTask : protected debug_console {
   protected:
     StateFieldRegistry& _registry;
 
+  private:
     void check_field_added(const bool added, const std::string& field_name) {
         if(!added) {
             #ifdef UNIT_TEST
@@ -66,6 +67,12 @@ class ControlTask : protected debug_console {
             assert(false);
         }
     }
+
+  #ifdef UNIT_TEST
+  public:
+  #else
+  protected:
+  #endif
 
     template<typename U>
     void add_internal_field(InternalStateField<U>& field) {
@@ -98,6 +105,8 @@ class ControlTask : protected debug_console {
         check_field_added(added, fault.name());
     }
 
+  private:
+
     void check_field_exists(const StateFieldBase* ptr, const std::string& field_type,
             const char* field_name) {
         if(!ptr) {
@@ -119,37 +128,44 @@ class ControlTask : protected debug_console {
         }
     }
 
+
+  #ifdef UNIT_TEST
+  public:
+  #else
+  protected:
+  #endif
+
     template<typename U>
     InternalStateField<U>* find_internal_field(const char* field, const char* file, const unsigned int line) {
-        auto field_ptr = _registry.find_internal_field(field);
+        InternalStateFieldBase* field_ptr = _registry.find_internal_field(field);
         check_field_exists(field_ptr, "internal", field);
         return static_cast<InternalStateField<U>*>(field_ptr);
     }
 
     template<typename U>
     ReadableStateField<U>* find_readable_field(const char* field, const char* file, const unsigned int line) {
-        auto field_ptr = _registry.find_readable_field(field);
+        ReadableStateFieldBase* field_ptr = _registry.find_readable_field(field);
         check_field_exists(field_ptr, "readable", field);
         return static_cast<ReadableStateField<U>*>(field_ptr);
     }
 
     template<typename U>
     WritableStateField<U>* find_writable_field(const char* field, const char* file, const unsigned int line) {
-        auto field_ptr = _registry.find_writable_field(field);
+        WritableStateFieldBase* field_ptr = _registry.find_writable_field(field);
         check_field_exists(field_ptr, "writable", field);
         return static_cast<WritableStateField<U>*>(field_ptr);
     }
 
     Event* find_event(const char* event, const char* file, const unsigned int line) {
-        auto event_ptr = _registry.find_event(event);
+        Event* event_ptr = _registry.find_event(event);
         check_field_exists(event_ptr, "event", event);
-        return *event_ptr;
+        return event_ptr;
     }
 
     Fault* find_fault(const char* fault, const char* file, const unsigned int line) {
-        auto fault_ptr = _registry.find_fault(fault);
+        Fault* fault_ptr = _registry.find_fault(fault);
         check_field_exists(fault_ptr, "fault", fault);
-        return *fault_ptr;
+        return fault_ptr;
     }
 };
 

--- a/test/test_fsw_control_task/test_control_task.cpp
+++ b/test/test_fsw_control_task/test_control_task.cpp
@@ -1,3 +1,4 @@
+#include "../StateFieldRegistryMock.hpp"
 #include <fsw/FCCode/ControlTask.hpp>
 
 #include <unity.h>
@@ -12,22 +13,87 @@ class DummyControlTask : public ControlTask<void> {
 };
 
 void test_task_initialization() {
-    StateFieldRegistry registry;
+    StateFieldRegistryMock registry;
     DummyControlTask task(registry);
 }
 
 void test_task_execute() {
-    StateFieldRegistry registry;
+    StateFieldRegistryMock registry;
     DummyControlTask task(registry);
     TEST_ASSERT_EQUAL(2, task.x);
     task.execute();
     TEST_ASSERT_EQUAL(3, task.x);
 }
 
+// Construction of dummy event and fault objects, used in the find and add tests below.
+// This construction also implicitly tests that constructing events and faults statically
+// does not cause a segfault or other undesirable behaviors.
+const char* event_print_fn(const unsigned int cc_count,
+    std::vector<ReadableStateFieldBase*>& fields)
+{
+    static const char* x = "";
+    return x;
+}
+static unsigned int cc_count = 0;
+static std::vector<ReadableStateFieldBase*> event_fields_list {};
+static Event event("event", event_fields_list, event_print_fn, cc_count);
+static Fault fault("fault", 1, cc_count);
+
+void test_task_find() {
+    StateFieldRegistryMock registry;
+    DummyControlTask task(registry);
+
+    // Finding internal, readable, and writable fields should work.
+    auto internal_fp = registry.create_internal_field<bool>("field1");
+    auto readable_fp = registry.create_readable_field<bool>("field2");
+    auto writable_fp = registry.create_writable_field<bool>("field3");
+    TEST_ASSERT_NOT_NULL(task.find_internal_field<bool>("field1", __FILE__, __LINE__));
+    TEST_ASSERT_NOT_NULL(task.find_readable_field<bool>("field2", __FILE__, __LINE__));
+    TEST_ASSERT_NOT_NULL(task.find_writable_field<bool>("field3", __FILE__, __LINE__));
+
+    // Finding a fault should work.
+    registry.add_fault(&fault);
+    TEST_ASSERT_NOT_NULL(task.find_fault("fault", __FILE__, __LINE__));
+
+    // Finding an event should work.
+    registry.add_event(&event);
+    TEST_ASSERT_NOT_NULL(task.find_event("event", __FILE__, __LINE__));
+}
+
+void test_task_add() {
+    StateFieldRegistryMock registry;
+    DummyControlTask task(registry);
+
+    // Adding an internal field should work.
+    InternalStateField<bool> field1("field1");
+    task.add_internal_field(field1);
+    TEST_ASSERT_NOT_NULL(registry.find_internal_field_t<bool>("field1"));
+
+    // Adding a readable field should work.
+    ReadableStateField<bool> field2("field2", Serializer<bool>());
+    task.add_readable_field(field2);
+    TEST_ASSERT_NOT_NULL(registry.find_readable_field_t<bool>("field2"));
+
+    // Adding a writable field should work.
+    WritableStateField<bool> field3("field3", Serializer<bool>());
+    task.add_writable_field(field3);
+    TEST_ASSERT_NOT_NULL(registry.find_writable_field_t<bool>("field3"));
+
+    // Adding a fault should work
+    task.add_fault(fault);
+    TEST_ASSERT_NOT_NULL(registry.find_fault_t("fault"));
+
+    // Adding an event should work
+    task.add_event(event);
+    TEST_ASSERT_NOT_NULL(registry.find_event_t("event"));
+}
+
 int test_control_task() {
     UNITY_BEGIN();
     RUN_TEST(test_task_initialization);
     RUN_TEST(test_task_execute);
+    RUN_TEST(test_task_find);
+    RUN_TEST(test_task_add);
     return UNITY_END();
 }
 


### PR DESCRIPTION
I recognize I'm not testing failure behavior for the find/add functions, but this is currently impossible to test since failures cause a dynamic assertion failure. Any suggestions on making the behavior more testable?