### PR TITLE
conversion from deg/sec to rad/sec

### DIFF
--- a/src/adcs/constants.hpp
+++ b/src/adcs/constants.hpp
@@ -119,7 +119,7 @@ static_assert(false, "Must define PAN_LEADER or PAN_FOLLOWER");
 #endif
 /** Maximum angular rate in radians per second that can be read from the
  *  gyroscope. */
-TRACKED_CONSTANT_SC(float, max_rd_omega, 125.0f * 0.03490658504f); // 2 * pi / 180
+TRACKED_CONSTANT_SC(float, max_rd_omega, 125.0f * 0.01745329251f); // pi / 180
 /** Minimum angular rate in radians per second that can be read from the
  *  gyroscope. */
 TRACKED_CONSTANT_SC(float, min_rd_omega, -max_rd_omega);


### PR DESCRIPTION
# PR Title: conversion from deg/sec to rad/sec

Fixes #. (Optional; sometimes PRs don't have an associated ticket)
no associated ticket

### Summary of changes
- conversion from deg/sec to rad/sec (should be pi/180 not 2pi/180)

### Testing
-N/A

### Constants
- conversion from deg/sec to rad/sec (should be pi/180 not 2pi/180)

### Documentation Evidence
Post to ReadTheDocs, or
- inline documentation is sufficient.