### PR TITLE
Serial Buffer Ini Fixes

### DIFF
--- a/configs/flight_and_test_envs.ini
+++ b/configs/flight_and_test_envs.ini
@@ -12,7 +12,7 @@ extends = teensy
 lib_extra_dirs = ${fsw_common.lib_extra_dirs}
 lib_deps = ${fsw_common.lib_deps}
 src_filter = ${fsw_common.src_filter} +<fsw/targets/teensy.cpp>
-build_flags = ${fsw_common.build_flags} -D SERIAL4_RX_BUFFER_SIZE=1024
+build_flags = ${fsw_common.build_flags} -D SERIAL3_RX_BUFFER_SIZE=512 -D SERIAL4_RX_BUFFER_SIZE=1024
 test_build_project_src = true
 
 #########################################################################

--- a/configs/flight_and_test_envs.ini
+++ b/configs/flight_and_test_envs.ini
@@ -12,6 +12,7 @@ extends = teensy
 lib_extra_dirs = ${fsw_common.lib_extra_dirs}
 lib_deps = ${fsw_common.lib_deps}
 src_filter = ${fsw_common.src_filter} +<fsw/targets/teensy.cpp>
+build_flags = ${fsw_common.build_flags} -D SERIAL4_RX_BUFFER_SIZE=1024
 test_build_project_src = true
 
 #########################################################################

--- a/configs/hardware_test_envs.ini
+++ b/configs/hardware_test_envs.ini
@@ -5,7 +5,7 @@
 [fsw_hardware_common]
 platform = teensy
 framework = arduino
-build_flags = -std=c++14 -Werror -Wall -D UNITY_INCLUDE_DOUBLE -O3 -DLIN_RANDOM_SEED=358264 -D PAN_LEADER -D SERIAL3_RX_BUFFER_SIZE=512
+build_flags = -std=c++14 -Werror -Wall -D UNITY_INCLUDE_DOUBLE -O3 -DLIN_RANDOM_SEED=358264 -D PAN_LEADER -D SERIAL3_RX_BUFFER_SIZE=512 -D SERIAL4_RX_BUFFER_SIZE=1024
 lib_extra_dirs = lib/fsw
 src_filter = +<fsw/FCCode/Drivers> +<fsw/FCCode/Devices> +<fsw/targets/teensy_stub.cpp>
 upload_protocol = teensy-cli
@@ -44,15 +44,12 @@ test_filter = test_prop
 [env:fsw_test_piksi_func]
 board = teensy36
 extends = fsw_hardware_common
-build_flags = -D SERIAL4_RX_BUFFER_SIZE=1024 -D LIN_RANDOM_SEED
 test_filter = test_piksi_func
 
 [env:fsw_teensy_36_test_piksi]
 board = teensy36
 extends = fsw_hardware_common
-build_flags = -D SERIAL4_RX_BUFFER_SIZE=1024 -D LIN_RANDOM_SEED
 test_filter = test_piksi
-
 
 ##########
 # ADCS


### PR DESCRIPTION
Fixes #315 
- Tagged @athena255 just for fyi on Quake related changes. Unsure if this fixes the weird Quake out of cycles messages.

### Summary of changes
- Added the Serial3RX buffer increase back to the .ini for teensy common
- Added the Serial4RX buffer increase back to the .ini for teensy common

### Testing

- PiksiControlTask was HITL tested with ptest (logs in the HITL logs folder), and functions as expected.
- Quake related CT's were not tested.

### Constants
No important constant changes.

### Documentation Evidence
- Added basic Piksi introduction documentation
- Added two lines documenting the Serial RX port requirements