### PR TITLE
Fix RWA Sensor Reading Scaling Issues

### DIFF
--- a/src/adcs/rwa.cpp
+++ b/src/adcs/rwa.cpp
@@ -148,7 +148,12 @@ void update_sensors(float speed_flt, float ramp_flt) {
   for (unsigned int i = 0; i < 3; i++)
     if (adcs[i].is_functional())
       if (adcs[i].end_read(val))
-        readings(i) = utl::fp(val, rwa::min_torque, rwa::max_torque);
+        readings(i) = readings(i) = 4.096f * ((float)val) / 2048.0f;
+        // ^^ Only converting to a voltage here
+        
+  // Go from voltage to torque reading
+  readings = (max_torque - min_torque) * readings / 3.3f +
+      min_torque * lin::ones<lin::Vector3f>();
 
   // Filter the results
   ramp_rd = ramp_rd + speed_flt * (readings - ramp_rd);

--- a/src/adcs/rwa.cpp
+++ b/src/adcs/rwa.cpp
@@ -148,7 +148,7 @@ void update_sensors(float speed_flt, float ramp_flt) {
   for (unsigned int i = 0; i < 3; i++)
     if (adcs[i].is_functional())
       if (adcs[i].end_read(val))
-        readings(i) = readings(i) = 4.096f * ((float)val) / 2048.0f;
+        readings(i) = 4.096f * ((float)val) / 2048.0f;
         // ^^ Only converting to a voltage here
         
   // Go from voltage to torque reading

--- a/src/adcs/rwa.cpp
+++ b/src/adcs/rwa.cpp
@@ -24,6 +24,8 @@
 #include "utl/convert.hpp"
 #include "utl/logging.hpp"
 
+#include <lin/generators/constants.hpp>
+
 namespace adcs {
 namespace rwa {
 
@@ -115,7 +117,12 @@ void update_sensors(float speed_flt, float ramp_flt) {
   for (unsigned int i = 0; i < 3; i++)
     if (adcs[i].is_functional())
       if (adcs[i].end_read(val))
-        readings(i) = utl::fp(val, rwa::min_speed_read, rwa::max_speed_read);
+        readings(i) = 4.096f * ((float)val) / 2048.0f;
+        // ^^ Only converting to a voltage here
+
+  // Go from voltage to speed reading
+  readings = (max_speed_read - min_speed_read) * readings / 3.3f +
+      min_speed_read * lin::ones<lin::Vector3f>();
 
   // Filter the results
   speed_rd = speed_rd + speed_flt * (readings - speed_rd);


### PR DESCRIPTION

# Fix RWA Torque and Speed Read Scaling Issues

Fixes #276 and other, unnoticed issues.

### Summary of changes
- Updated scaling for torque reads.
- Updated scaling for speed reads.

In both cases, the issue was due to us not converting first to a voltage and then to a torque/wheel speed.

What's happening in the code now, is scaling from the 12-bit signed value to `+/- 4.096 V` (hence the `2048=2^11`). From there, we scale in the range `0-3.3V` to our full output range.

### Testing

Will hopefully get to see this in action during an ADCS hardware checkout.

### Constants

NA

### Documentation Evidence

See inline comments.
