### PR TITLE
Update teensy36_common

### DIFF
--- a/configs/common_software.ini
+++ b/configs/common_software.ini
@@ -46,9 +46,12 @@ build_flags = ${common.build_flags} -D NDEBUG -O3
 upload_protocol = teensy-cli
 
 [env:teensy36_common]
-extends = teensy35_common
-board = teensy36
+extends = common
 platform = teensy
+board = teensy36
+framework = arduino
+build_flags = ${common.build_flags} -D NDEBUG -O3
+upload_protocol = teensy-cli
 
 #########################################################################
 # Simple test utility for serializers


### PR DESCRIPTION
# Update teensy36_common

### Summary of changes
- Updated teensy36_common to not run dat folder in tests

### Testing
- ADCS ptest works as expected

### Constants
N/A

### Documentation Evidence
platformio.ini is self-documenting
