### PR TITLE
fix downlink parser

### DIFF
--- a/src/gsw/parsers/src/DownlinkParser.cpp
+++ b/src/gsw/parsers/src/DownlinkParser.cpp
@@ -146,20 +146,34 @@ std::string DownlinkParser::process_downlink_packet(const std::vector<char>& pac
             for(ReadableStateFieldBase* field : flow->field_list) {
                 Event* event = registry.find_event(field->name());
                 if (event) {
+                    // Store the original values of the control cycle count and data fields
+                    unsigned int current_ccno = event->ccno->get();
+                    std::vector<bit_array> field_bits_original;
+                    for (ReadableStateFieldBase* data_field : event->_data_fields()) {
+                        data_field->serialize();
+                        field_bits_original.push_back(data_field->get_bit_array());
+                    }
+
                     const std::vector<bool>::iterator event_end_it =
                         frame_bits.begin() + event->get_bit_array().size();
                     
                     const std::vector<bool> event_bits(frame_bits.begin(), event_end_it);
                     event->set_bit_array(event_bits);
                     
-                    unsigned int current_ccno = event->ccno->get();
                     event->deserialize();
                     unsigned int event_ccno = event->ccno->get();
-                    event->ccno->set(current_ccno);
 
                     ret["data"][event->name()]["control_cycle_number"] = event_ccno;
                     for (ReadableStateFieldBase* data_field: event->_data_fields()) {
                         ret["data"][event->name()]["field_data"][data_field->name()] = std::string(data_field->print());
+                    }
+
+                    // Reapply the original values to the control cycle count and data fields
+                    event->ccno->set(current_ccno);
+                    for (size_t i = 0; i < field_bits_original.size(); i++) {
+                        ReadableStateFieldBase* field = event->_data_fields()[i];
+                        field->set_bit_array(field_bits_original[i]);
+                        field->deserialize();
                     }
                     frame_bits.erase(frame_bits.begin(), event_end_it);
                 }

--- a/test/test_gsw_downlink_parser/test_gsw_downlink_parser.cpp
+++ b/test/test_gsw_downlink_parser/test_gsw_downlink_parser.cpp
@@ -45,6 +45,7 @@ class TestFixture {
         foo1_fp->set(400);
 
         data1_f.set(false);
+        reg.add_readable_field(static_cast<ReadableStateFieldBase*>(&data1_f));
         reg.add_event(&event);
 
         parser = std::make_unique<DownlinkParserMock>(reg, flow_data);
@@ -55,6 +56,7 @@ class TestFixture {
 
         event.signal();
         cycle_count_fp->set(40);
+        data1_f.set(true);
 
         snapshot_fp = reg.find_internal_field_t<char*>("downlink.ptr");
         snapshot_size_bytes_fp = reg.find_internal_field_t<size_t>("downlink.snap_size");
@@ -93,6 +95,7 @@ void test_task_execute() {
     TEST_ASSERT_EQUAL(tf.foo1_fp->get(), foo1);
     TEST_ASSERT_EQUAL(20, event_ccno);
     TEST_ASSERT_TRUE(data1=="false");
+    TEST_ASSERT_TRUE(tf.data1_f.get());
 
     // Test that metadata is OK
     TEST_ASSERT_EQUAL(tf.cycle_count_fp->get(), downlink["metadata"]["cycle_no"]);


### PR DESCRIPTION
# Fix Downlink Parser Bug

Fixes #343 

### Summary of changes
Record the original values of the event data fields before deserializing the event, and then reapplying the original values to the fields after the downlink is parsed

### Testing
In the test file, I changed the event data field (data1_f) from false to true after the event was signaled. I then tested that data1_f remained true even after the downlink was parsed.