### PR TITLE
Added Auto Cycle to DebugTask

### DIFF
--- a/src/fsw/FCCode/DebugTask.cpp
+++ b/src/fsw/FCCode/DebugTask.cpp
@@ -3,8 +3,8 @@
 #ifdef FUNCTIONAL_TEST
 DebugTask::DebugTask(StateFieldRegistry &registry, unsigned int offset)
     : TimedControlTask<void>(registry, "debug", offset),
-      start_cycle_f("cycle.start", Serializer<bool>(),
-      auto_cycle_f("cycle.auto", Serializer<bool>())) {
+      start_cycle_f("cycle.start", Serializer<bool>()),
+      auto_cycle_f("cycle.auto", Serializer<bool>()) {
   add_writable_field(start_cycle_f);
   add_writable_field(auto_cycle_f);
   init();

--- a/src/fsw/FCCode/DebugTask.cpp
+++ b/src/fsw/FCCode/DebugTask.cpp
@@ -7,6 +7,7 @@ DebugTask::DebugTask(StateFieldRegistry &registry, unsigned int offset)
       auto_cycle_f("cycle.auto", Serializer<bool>()) {
   add_writable_field(start_cycle_f);
   add_writable_field(auto_cycle_f);
+  auto_cycle_f.set(false);
   init();
 }
 #else
@@ -19,13 +20,13 @@ DebugTask::DebugTask(StateFieldRegistry &registry, unsigned int offset)
 void DebugTask::execute() {
 #ifdef FUNCTIONAL_TEST
   start_cycle_f.set(false);
-
   if(auto_cycle_f.get()){
-  while (!start_cycle_f.get())
     process_commands(_registry);
   }
   else{
-    process_commands(_registry);
+    // !auto_cycle_f.get() is false once auto_cycle_f is true, ending the while loop
+    while (!start_cycle_f.get() && !auto_cycle_f.get()) 
+      process_commands(_registry);
   }
 #endif
 }

--- a/src/fsw/FCCode/DebugTask.cpp
+++ b/src/fsw/FCCode/DebugTask.cpp
@@ -3,8 +3,10 @@
 #ifdef FUNCTIONAL_TEST
 DebugTask::DebugTask(StateFieldRegistry &registry, unsigned int offset)
     : TimedControlTask<void>(registry, "debug", offset),
-      start_cycle_f("cycle.start", Serializer<bool>()) {
+      start_cycle_f("cycle.start", Serializer<bool>(),
+      auto_cycle_f("cycle.auto", Serializer<bool>())) {
   add_writable_field(start_cycle_f);
+  add_writable_field(auto_cycle_f);
   init();
 }
 #else
@@ -17,8 +19,14 @@ DebugTask::DebugTask(StateFieldRegistry &registry, unsigned int offset)
 void DebugTask::execute() {
 #ifdef FUNCTIONAL_TEST
   start_cycle_f.set(false);
+
+  if(auto_cycle_f.get()){
   while (!start_cycle_f.get())
     process_commands(_registry);
+  }
+  else{
+    process_commands(_registry);
+  }
 #endif
 }
 

--- a/src/fsw/FCCode/DebugTask.hpp
+++ b/src/fsw/FCCode/DebugTask.hpp
@@ -31,8 +31,7 @@ protected:
    */
   WritableStateField<bool> start_cycle_f;
   /**
-   * @brief If this state field is true, Debug task will not wait for start_cycle_f
-   * to be true before calling process commands and moving on.
+   * @brief If this state field is true, DebugTask will call process_commands() once, then move on.
    * 
    */
   WritableStateField<bool> auto_cycle_f;

--- a/src/fsw/FCCode/DebugTask.hpp
+++ b/src/fsw/FCCode/DebugTask.hpp
@@ -30,6 +30,12 @@ protected:
    * with the simulation.
    */
   WritableStateField<bool> start_cycle_f;
+  /**
+   * @brief If this state field is true, Debug task will not wait for start_cycle_f
+   * to be true before calling process commands and moving on.
+   * 
+   */
+  WritableStateField<bool> auto_cycle_f;
 #endif
 };
 


### PR DESCRIPTION
# Added Auto Cycle to DebugTask
Useful when debugging, and will be used later in PiksiCheckoutCase

### Summary of changes
- Added a `cycle.auto` state field to DebugTask

### Testing
Ran with ptest EmptyCase, pan.cycle_no automatically increments as expected. Stops auto cycling whenever cycle.auto is false.

### Constants
N/A

### Documentation Evidence
Post to ReadTheDocs, or
- Documentation ready to go as soon as this PR is approved.
