### PR TITLE
Fix bitsizes in telem info generator

### DIFF
--- a/src/common/SerializerTypes.inl
+++ b/src/common/SerializerTypes.inl
@@ -806,6 +806,10 @@ class Serializer<lin::Vector<T, N>> : public SerializerBase<lin::Vector<T, N>> {
         for(unsigned int i = 0; i < N; i++) src_cpy[i] = src(i);
         return _arr_sr.print(src_cpy);
     }
+
+    unsigned int bitsize() const {
+        return _arr_sr.bitsize();
+    }
 };
 
 /**

--- a/telemetry
+++ b/telemetry
@@ -7,7 +7,7 @@
     },
     "fields": {
         "adcs.compute.vec1.current": {
-            "bitsize": 0,
+            "bitsize": 100,
             "flow_id": 14,
             "max": 1.0,
             "min": 0.0,
@@ -15,7 +15,7 @@
             "writable": true
         },
         "adcs.compute.vec1.desired": {
-            "bitsize": 0,
+            "bitsize": 100,
             "flow_id": 14,
             "max": 1.0,
             "min": 0.0,
@@ -23,7 +23,7 @@
             "writable": true
         },
         "adcs.compute.vec2.current": {
-            "bitsize": 0,
+            "bitsize": 100,
             "flow_id": 14,
             "max": 1.0,
             "min": 0.0,
@@ -31,7 +31,7 @@
             "writable": true
         },
         "adcs.compute.vec2.desired": {
-            "bitsize": 0,
+            "bitsize": 100,
             "flow_id": 14,
             "max": 1.0,
             "min": 0.0,
@@ -465,7 +465,7 @@
             "writable": false
         },
         "adcs_monitor.gyr_vec": {
-            "bitsize": 0,
+            "bitsize": 48,
             "flow_id": 24,
             "max": 2.181661605834961,
             "min": -2.181661605834961,
@@ -587,7 +587,7 @@
             "writable": false
         },
         "adcs_monitor.mag1_vec": {
-            "bitsize": 0,
+            "bitsize": 48,
             "flow_id": 24,
             "max": 0.004999999888241291,
             "min": -0.004999999888241291,
@@ -601,7 +601,7 @@
             "writable": false
         },
         "adcs_monitor.mag2_vec": {
-            "bitsize": 0,
+            "bitsize": 48,
             "flow_id": 24,
             "max": 0.0031999999191612005,
             "min": -0.0031999999191612005,
@@ -615,7 +615,7 @@
             "writable": false
         },
         "adcs_monitor.rwa_speed_rd": {
-            "bitsize": 0,
+            "bitsize": 48,
             "flow_id": 7,
             "max": 1047.199951171875,
             "min": -1047.199951171875,
@@ -623,7 +623,7 @@
             "writable": false
         },
         "adcs_monitor.rwa_torque_rd": {
-            "bitsize": 0,
+            "bitsize": 48,
             "flow_id": 7,
             "max": 0.004187500569969416,
             "min": -0.004187500569969416,
@@ -645,7 +645,7 @@
             "writable": false
         },
         "adcs_monitor.ssa_vec": {
-            "bitsize": 0,
+            "bitsize": 48,
             "flow_id": 24,
             "max": 1.0,
             "min": -1.0,
@@ -947,13 +947,13 @@
             "writable": true
         },
         "attitude_estimator.q_body_eci": {
-            "bitsize": 0,
+            "bitsize": 29,
             "flow_id": 3,
             "type": "lin float quaternion",
             "writable": false
         },
         "attitude_estimator.w_body": {
-            "bitsize": 0,
+            "bitsize": 96,
             "flow_id": 3,
             "max": 55.0,
             "min": -55.0,
@@ -1509,7 +1509,7 @@
             "writable": true
         },
         "orbit.baseline_pos": {
-            "bitsize": 0,
+            "bitsize": 100,
             "flow_id": 2,
             "max": 100000.0,
             "min": 0.0,
@@ -1517,7 +1517,7 @@
             "writable": false
         },
         "orbit.pos": {
-            "bitsize": 0,
+            "bitsize": 100,
             "flow_id": 2,
             "max": 100000.0,
             "min": 0.0,


### PR DESCRIPTION
Fixes #393

### Summary of changes
- Get bitsize to be correct inside the telemetry info generator for lin fields

### Testing
The telemetry was updated correctly, hence the feature works.

### Constants
No constants changed.

### Telemetry
No telemetry was added, but the bitsizes of lin vectors were fixed.

### Documentation Evidence
This is a minor bugfix with no changes to documentation required, since we're simply conforming the behavior of the tlm info generator utility to the expected behavior.
