### PR TITLE
Datastore stress test (which solved #378)

### DIFF
--- a/ptest/tests/datastore_stress_test.py
+++ b/ptest/tests/datastore_stress_test.py
@@ -1,0 +1,29 @@
+from ..data_consumers import Datastore
+import os, tempfile, timeit
+import pylab as plt
+
+# Note, running this stress test requires exporting STRESS_TEST=1 as an
+# environment variable.
+def test_datastore_stressfully():
+    if "STRESS_TEST" not in os.environ:
+        return
+    
+    tempdir = tempfile.mkdtemp() + "/datastore_test_dir"
+    os.makedirs(tempdir, exist_ok=True)
+    datastore = Datastore("test_device", tempdir)
+    datastore.start()
+
+    elapsed_times = []
+
+    for x in range(0, 10000):
+        start_time = timeit.default_timer()
+        for y in range(0, 100):
+            datastore.put({"field": "test_field", "val" : "val", "time" : "2"})
+        elapsed_time = int((timeit.default_timer() - start_time) * 1E6)
+        elapsed_times.append(elapsed_time)
+
+    plt.plot(elapsed_times)
+    plt.ylabel("Duration to write 100 database values (microseconds)")
+    plt.show()
+
+    datastore.stop()


### PR DESCRIPTION
Fixed #378.

### Summary of changes
- Added a datastore stress test that reports a linear increase in insertion time. Running the stress test requires setting the `STRESS_TEST` environment variable:

```
export STRESS_TEST=1
python -m pytest ptest/tests/datastore_stress_test.py
```

Results:
<img width="886" alt="Screen Shot 2020-04-20 at 11 21 27 AM" src="https://user-images.githubusercontent.com/5239500/79770033-dbd7a880-82fa-11ea-8e4f-aef1bea5afca.png">

### Testing
This is a PR that adds testing.

### Constants
No constants added.

### Telemetry
No telemetry added.

### Documentation Evidence
Documentation with the issue tickets is sufficient, since this is just a bug, not a feature.
