### PR TITLE
Uplink console for both radio session and state session

### DIFF
--- a/ptest/radio_session.py
+++ b/ptest/radio_session.py
@@ -94,6 +94,8 @@ class RadioSession(object):
             created_uplink = self.uplink_console.create_uplink(fields, vals, "uplink.sbd")
             if not created_uplink: return False
             os.system("./ptest/send_uplink uplink.sbd")
+            os.remove("uplink.sbd") 
+            os.remove("uplink.json") 
             return True
         else:
             return False

--- a/ptest/radio_session.py
+++ b/ptest/radio_session.py
@@ -27,7 +27,7 @@ class RadioSession(object):
     '''
 
 
-    def __init__(self, device_name, imei, simulation_run_dir, tlm_config):
+    def __init__(self, device_name, imei, uplink_console, simulation_run_dir, tlm_config):
         '''
         Initializes state session with the Quake radio.
         '''
@@ -35,6 +35,9 @@ class RadioSession(object):
         # Device connection
         self.device_name = device_name
         self.imei=imei
+
+        # Uplink console
+        self.uplink_console = uplink_console
 
         #Flask server connection
         self.flask_server=tlm_config["webservice"]["server"]
@@ -88,9 +91,8 @@ class RadioSession(object):
             for i in range(len(fields)):
                 updated_fields[fields[i]]=vals[i]
 
-            #create a JSON file with the updated statefields and send it to the iridium email
-            with open('uplink.sbd', 'w') as json_uplink:
-                json.dump(updated_fields, json_uplink)
+            created_uplink = self.uplink_console.create_uplink(fields, vals, "uplink.sbd")
+            if not created_uplink: return False
             os.system("./ptest/send_uplink uplink.sbd")
             return True
         else:

--- a/ptest/runsim.py
+++ b/ptest/runsim.py
@@ -5,6 +5,7 @@ from .cases.base import TestCaseFailure
 from .configs.schemas import *
 from .state_session import StateSession
 from .radio_session import RadioSession
+from .uplink_console import UplinkConsole
 from .cmdprompt import StateCmdPrompt
 from .simulation import Simulation, SingleSatSimulation
 import json, sys, os, tempfile, time, threading, signal, traceback
@@ -42,6 +43,8 @@ class PTest(object):
         pan_logo_filepath = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'pan_logo.txt')
         with open(pan_logo_filepath, 'r') as pan_logo_file:
             print(pan_logo_file.read())
+
+        self.uplink_console = UplinkConsole(self.simulation_run_dir)
 
         self.is_running = True
         self.set_up_devices()
@@ -104,7 +107,7 @@ class PTest(object):
                     # pty isn't defined because we're on Windows
                     self.stop_all(f"Cannot connect to a native binary for device {device_name}, since the current OS is Windows.")
 
-            device_session = StateSession(device_name, self.simulation_run_dir)
+            device_session = StateSession(device_name, self.uplink_console, self.simulation_run_dir)
 
             # Connect to device, failing gracefully if device connection fails
             if device_session.connect(device["port"], device["baud_rate"]):
@@ -137,7 +140,7 @@ class PTest(object):
 
             if radio['connect']:
                 radio_data_name = radio_connected_device + "_radio"
-                radio_session = RadioSession(radio_name, imei, self.simulation_run_dir, self.tlm_config)
+                radio_session = RadioSession(radio_name, imei, self.uplink_console, self.simulation_run_dir, self.tlm_config)
                 self.radios[radio_name] = radio_session
 
     def set_up_sim(self):
@@ -182,6 +185,9 @@ class PTest(object):
         print("Stopping binary monitor thread...")
         time.sleep(1.0)
         self.binary_monitor_thread.join()
+
+        print("Stopping uplink console...")
+        self.uplink_console.close()
 
         print("Stopping simulation (please be patient)...")
         try:

--- a/ptest/state_session.py
+++ b/ptest/state_session.py
@@ -346,7 +346,6 @@ class StateSession(object):
         # Send a command to the console to process the uplink packet
         json_cmd = {
             'mode': ord('u'),
-            'field': 'pan.state',
             'val': uplink_packet,
             'length': uplink_packet_length
         }

--- a/ptest/state_session.py
+++ b/ptest/state_session.py
@@ -25,13 +25,16 @@ class StateSession(object):
     they won't trip over each other in setting/receiving variables from the connected flight computer.
     '''
 
-    def __init__(self, device_name, simulation_run_dir):
+    def __init__(self, device_name, uplink_console, simulation_run_dir):
         '''
         Initializes state session with a device.
         '''
 
         # Device connection
         self.device_name = device_name
+
+        # Uplink console
+        self.uplink_console = uplink_console
 
         # Data logging
         self.datastore = Datastore(device_name, simulation_run_dir)
@@ -55,16 +58,6 @@ class StateSession(object):
 
         # Simulation
         self.overriden_variables = set()
-
-        # Open a subprocess to Uplink Producer. Compile it if it is not available.
-        uplink_producer_filepath = ".pio/build/gsw_uplink_producer/program" 
-        if not os.path.exists(uplink_producer_filepath):
-            print("Compiling the uplink producer.")
-            os.system("pio run -e gsw_uplink_producer > /dev/null")
-
-        master_fd, slave_fd = pty.openpty()
-        self.uplink_producer = subprocess.Popen([uplink_producer_filepath], stdin=master_fd, stdout=master_fd)
-        self.uplink_console = serial.Serial(os.ttyname(slave_fd), 9600, timeout=1)
 
     def connect(self, console_port, baud_rate):
         '''
@@ -350,42 +343,6 @@ class StateSession(object):
             if val == "true": return True
             if val == "false": return False
         return None
-    
-    def create_uplink(self, fields, vals, filename):
-        '''
-        Puts fields and values in a JSON document and sends the JSON 
-        object to the uplink producer console. This results in the creation
-        of an SBD file with the given filename holding an uplink packet
-        '''
-        # Create a JSON file with all the fields and values
-        telem_json={}
-        for field, val in zip(fields, vals):
-            value = self.get_val(val)
-            if value is not None:
-                telem_json[field]=value
-            else:
-                logline = "Failed:   " + json.dumps(telem_json) + "\n"
-                logline += f"Error:    Unable to add {field}: {val} to uplink JSON file"
-                self.raw_logger.put(logline)
-                return False
-        with open('uplink.json', 'w') as telem_file:
-            json.dump(telem_json, telem_file)
-
-        # Write the JSON file into Uplink Producer - should result in the creation of an sbd file
-        # holding the uplink packet.
-        self.uplink_console.write(("uplink.json\n").encode())
-        self.uplink_console.write((str(filename)+"\n").encode())
-        response = json.loads(self.uplink_console.readline().rstrip())
-
-        # Check that the uplink was successfully created
-        if 'error' in response:
-            logline = "Failed:   " + json.dumps(telem_json) + "\n"
-            logline += "Error:    "+response['error']
-            self.raw_logger.put(logline)
-            return False
-
-        self.raw_logger.put("Uplink:   " + json.dumps(telem_json))
-        return True
 
     def send_uplink(self, filename):
         '''
@@ -432,7 +389,7 @@ class StateSession(object):
         ]
         fields, vals = zip(*field_val_pairs)
 
-        success = self.create_uplink(fields, vals, "uplink.sbd")
+        success = self.uplink_console.create_uplink(fields, vals, "uplink.sbd")
 
         # If the uplink packet exists, send it to the FlightSoftware console
         if success and os.path.exists("uplink.sbd"):
@@ -502,7 +459,6 @@ class StateSession(object):
         self.running_logger = False
         self.check_msgs_thread.join()
         self.console.close()
-        self.uplink_console.close()
         self.dp_console.close()
 
         self.datastore.stop()

--- a/ptest/state_session.py
+++ b/ptest/state_session.py
@@ -324,26 +324,6 @@ class StateSession(object):
         '''
         return self.write_multiple_states([field], [self._val_to_str(args)], kwargs.get('timeout'))
 
-    def get_val(self, val):
-        '''
-        Recives string representation of a value and returns the value as a bool, int, or float
-        If the value can't be determined, returns None;
-        "true" --> true (bool)
-        "5" --> 5 (int)
-        "0.05" --> 0.05 (float)
-        "dchkjdda" --> None
-        '''
-        try:
-            f=float(val)
-            i=int(f)
-            if f!=i: 
-                return f
-            return i
-        except:
-            if val == "true": return True
-            if val == "false": return False
-        return None
-
     def send_uplink(self, filename):
         '''
         Gets the uplink packet from the given file. Sends the hex 

--- a/ptest/uplink_console.py
+++ b/ptest/uplink_console.py
@@ -1,0 +1,69 @@
+import json, pty, subprocess, serial, os
+from .data_consumers import Logger
+
+class UplinkConsole(object):
+    """
+    Class that interfaces with gsw_uplink_producer to create uplink packets
+    from JSON descriptions.
+    """
+
+    def __init__(self, data_dir):
+        # Open a subprocess to Uplink Producer. Compile it if it is not available.
+        uplink_producer_filepath = ".pio/build/gsw_uplink_producer/program" 
+        if not os.path.exists(uplink_producer_filepath):
+            print("Compiling the uplink producer.")
+            os.system("pio run -e gsw_uplink_producer > /dev/null")
+
+        master_fd, slave_fd = pty.openpty()
+        self.uplink_producer = subprocess.Popen([uplink_producer_filepath], stdin=master_fd, stdout=master_fd)
+        self.uplink_console = serial.Serial(os.ttyname(slave_fd), 9600, timeout=1)
+
+        self.logger = Logger("UplinkConsole", data_dir)
+
+    def create_uplink(self, fields, vals, filename):
+        """
+        Puts fields and values in a JSON document and sends the JSON 
+        object to the uplink producer console. This results in the creation
+        of an SBD file with the given filename holding an uplink packet
+        """
+
+        # Create a JSON file with all the fields and values
+        telem_json={}
+        for field, val in zip(fields, vals):
+            value = self.get_val(val)
+            if value is not None:
+                telem_json[field]=value
+            else:
+                logline = "Failed:   " + json.dumps(telem_json) + "\n"
+                logline += f"Error:    Unable to add {field}: {val} to uplink JSON file"
+                self.logger.put(logline)
+                return False
+        with open('uplink.json', 'w') as telem_file:
+            json.dump(telem_json, telem_file)
+
+        # Write the JSON file into Uplink Producer - should result in the creation of an sbd file
+        # holding the uplink packet.
+        self.uplink_console.write(("uplink.json\n").encode())
+        self.uplink_console.write((str(filename)+"\n").encode())
+        response = json.loads(self.uplink_console.readline().rstrip())
+
+        # Check that the uplink was successfully created
+        if 'error' in response:
+            logline = "Failed:   " + json.dumps(telem_json) + "\n"
+            logline += "Error:    "+response['error']
+            self.logger.put(logline)
+            return False
+
+        self.logger.put("Uplink:   " + json.dumps(telem_json))
+        return True
+
+    def close(self):
+        if not hasattr(self, "stopped"):
+            self.stopped = False
+
+        if self.stopped: return
+
+        self.uplink_producer.kill()
+        self.uplink_console.close()
+        self.logger.stop()
+        self.stopped = True

--- a/ptest/uplink_console.py
+++ b/ptest/uplink_console.py
@@ -20,6 +20,26 @@ class UplinkConsole(object):
 
         self.logger = Logger("UplinkConsole", data_dir)
 
+    def get_val(self, val):
+        '''
+        Recives string representation of a value and returns the value as a bool, int, or float
+        If the value can't be determined, returns None;
+        "true" --> true (bool)
+        "5" --> 5 (int)
+        "0.05" --> 0.05 (float)
+        "dchkjdda" --> None
+        '''
+        try:
+            f=float(val)
+            i=int(f)
+            if f!=i: 
+                return f
+            return i
+        except:
+            if val == "true": return True
+            if val == "false": return False
+        return None
+
     def create_uplink(self, fields, vals, filename):
         """
         Puts fields and values in a JSON document and sends the JSON 

--- a/src/common/debug_console.cpp
+++ b/src/common/debug_console.cpp
@@ -268,7 +268,8 @@ void debug_console::process_commands(const StateFieldRegistry& registry) {
 
                 // Get the uplink packet as a char pointer. 
                 // Add "\x" to the end to allow us to parse the uplink string
-                char* uplink_packet = (char *) malloc(1 + strlen(packet)+ strlen("\\x"));
+                static char uplink_packet[300];
+                memset(uplink_packet, 0, 300);
                 strcpy(uplink_packet, packet);
                 strcat(uplink_packet, "\\x");
 
@@ -278,13 +279,14 @@ void debug_console::process_commands(const StateFieldRegistry& registry) {
 
                 // Parse the uplink packet; convert it from a hex string to an array of integers.
                 // Token holds a single hex value in uplink string; can't possibly be longer than the string length of the packet.
-                char token[strlen(packet)]; 
+                char token[strlen(packet)];
+                char* uplink_packet_ptr = uplink_packet;
                 for (i=0; i<uplink_packet_len; i++) {
                     // Get the hex string (i.e "4c") and put it in the token char array
-                    uplink_packet+=2;
+                    uplink_packet_ptr+=2;
                     memset(token, 0, uplink_packet_len); // Clear the token array
-                    for (size_t idx = 0; uplink_packet[0] != '\\'; idx++, uplink_packet++) {
-                        token[idx] = uplink_packet[0];
+                    for (size_t idx = 0; uplink_packet_ptr[0] != '\\'; idx++, uplink_packet_ptr++) {
+                        token[idx] = uplink_packet_ptr[0];
                     }
 
                     // Get the decimal value of the token/hex string (i.e 67) and add it to data array

--- a/src/common/debug_console.cpp
+++ b/src/common/debug_console.cpp
@@ -206,7 +206,7 @@ void debug_console::process_commands(const StateFieldRegistry& registry) {
         JsonVariant field = msgs[i]["field"];
 
         // Check sanity of data
-        if (field.isNull()) continue;
+        if (msg_mode.as<unsigned char>() != 'u' && field.isNull()) continue;
 
         const char* field_name = field.as<const char*>();
         if (msg_mode.isNull()) {


### PR DESCRIPTION
Closes #451.

### Summary of changes
- Enabled sending of real telemetry via RadioSession
- Made RadioSession and StateSession share an _uplink console_, which contains the uplink producer process

### Testing
Still doing it

### Constants
None added; PTest only.

### Telemetry
None added; PTest only.

### Documentation Evidence
This conforms RadioSession to specified behavior.
