### PR TITLE
fixed uplinks on ptest hootl! :D

### DIFF
--- a/ptest/configs/schemas.py
+++ b/ptest/configs/schemas.py
@@ -4,6 +4,8 @@ from cerberus import Validator
 ptest_config_schema = {
     "seed" : {"type" : "integer"},
     "single_sat_sim" : {"type": "boolean"},
+    "uplink_producer_filepath": {"type": "string"},
+    "downlink_parser_filepath": {"type": "string"},
     "devices" : {
         "type" : "list",
         "schema" : {
@@ -56,6 +58,13 @@ ptest_config_schema = {
                 "schema": {
                     "server": { "type": "string" , "required" : True},
                     "port": { "type": "integer" , "required" : True}
+                }
+            },
+            "elasticsearch": {
+                "type" : "dict",
+                "schema": {
+                    "server": { "type": "string" , "required" : True },
+                    "port": { "type": "integer" , "required" : True }
                 }
             }
         }

--- a/ptest/state_session.py
+++ b/ptest/state_session.py
@@ -421,7 +421,6 @@ class StateSession(object):
         # Send a command to the console to process the uplink packet
         json_cmd = {
             'mode': ord('u'),
-            'field': 'pan.state',
             'val': uplink_packet,
             'length': uplink_packet_length
         }

--- a/src/common/debug_console.cpp
+++ b/src/common/debug_console.cpp
@@ -206,7 +206,7 @@ void debug_console::process_commands(const StateFieldRegistry& registry) {
         JsonVariant field = msgs[i]["field"];
 
         // Check sanity of data
-        if (field.isNull()) continue;
+        if (msg_mode.as<unsigned char>()!='u' && field.isNull()) continue;
 
         const char* field_name = field.as<const char*>();
         if (msg_mode.isNull()) {


### PR DESCRIPTION
# Fixed Uplinks on Ptest HOOTL

### Summary of changes
- Sending uplinks on ptest wasn't working with HOOTL. It turns out that there are a limited number of messages you can send to the debug console in a single JSON command. The uplink JSON command had three values: field, uplink packet, and uplink packet length. The uplink packet length value got cut off, so to speak, from the rest of the JSON command when it was sent to the debug console.
- The debug console won't read a JSON command sent from state session if `field.isNull()` is true. So, that's why I would add a random field (i.e "pan.state") along with the rest of the uplink JSON command to bypass this.
- I changed it so that now the debug console won't read a JSON command sent from state session if `field.isNull()` is true AND if the mode if not 'u' (i.e the command is to read or write a state). Now, the uplink JSON command has the only two values really needed for the debug console to do an uplink: the uplink packet and the uplink packet length.

### Testing
I can successfully uplink various types of statefields with HOOTL and with HITL with a Teensy 3.6. I don't have a 3.5, so I can't test that behavior. I would upload logs to the OneDrive, but they'd be exactly the same as the logs I uploaded for a previous pr where I first added uplinking on ptest, so I don't think it's necessary in this case.