### PR TITLE
Fix testcase error handling

### DIFF
--- a/ptest/cases/quake_fault_handler.py
+++ b/ptest/cases/quake_fault_handler.py
@@ -45,7 +45,7 @@ class QuakeFaultHandler_Fast(SingleSatOnlyCase):
     def collect_diagnostic_data(self):
         self.qfh_state = self.rs("qfh.state")
         self.rs("pan.state")
-        self.powercycle_happening = self.rs("gomspace.power_cycle_output1_cmd")
+        self.powercycle_happening = self.rs("gomspace.power_cycle_output3_cmd")
         self.rs("pan.cycle_no")
 
     def run_case_singlesat(self):

--- a/ptest/cases/quake_fault_handler.py
+++ b/ptest/cases/quake_fault_handler.py
@@ -38,7 +38,7 @@ class QuakeFaultHandler_Fast(SingleSatOnlyCase):
 
     def check_quake_powercycled(self):
         if not self.powercycle_happening:
-            self.logger.put("Quake radio was not powercycled.")
+            raise TestCaseFailure("Quake radio was not powercycled.")
         else:
             self.logger.put("Comms blackout caused a powercycle of Quake.")
 

--- a/src/fsw/FCCode/GomspaceController.hpp
+++ b/src/fsw/FCCode/GomspaceController.hpp
@@ -106,10 +106,10 @@ class GomspaceController : public TimedControlTask<void> {
     // Command statefields to control the Gomspace outputs. Will
     // be set by various individual subsystems and the ground.
     Serializer<bool> power_cycle_outputs_cmd_sr;
-    WritableStateField<bool> power_cycle_output1_cmd_f;
+    WritableStateField<bool> power_cycle_output1_cmd_f; // Piksi
     WritableStateField<bool> power_cycle_output2_cmd_f;
-    WritableStateField<bool> power_cycle_output3_cmd_f;
-    WritableStateField<bool> power_cycle_output4_cmd_f;
+    WritableStateField<bool> power_cycle_output3_cmd_f; // Quake
+    WritableStateField<bool> power_cycle_output4_cmd_f; // ADCS Teensy
     WritableStateField<bool> power_cycle_output5_cmd_f;
     WritableStateField<bool> power_cycle_output6_cmd_f;
 

--- a/src/fsw/FCCode/QuakeFaultHandler.cpp
+++ b/src/fsw/FCCode/QuakeFaultHandler.cpp
@@ -10,7 +10,7 @@ QuakeFaultHandler::QuakeFaultHandler(StateFieldRegistry &r) : FaultHandlerMachin
     radio_state_fp = find_readable_field<unsigned char>("radio.state", __FILE__, __LINE__);
     last_checkin_cycle_fp = find_readable_field<unsigned int>("radio.last_comms_ccno", __FILE__,
                                                               __LINE__);
-    power_cycle_radio_fp = find_writable_field<bool>("gomspace.power_cycle_output1_cmd", __FILE__,
+    power_cycle_radio_fp = find_writable_field<bool>("gomspace.power_cycle_output3_cmd", __FILE__,
                                                      __LINE__);
 
     cur_state.set(static_cast<unsigned char>(qfh_state_t::unfaulted));

--- a/test/test_fsw_fault_handler/test_fixture_main_fh.cpp
+++ b/test/test_fsw_fault_handler/test_fixture_main_fh.cpp
@@ -14,7 +14,7 @@ TestFixtureMainFHBase::TestFixtureMainFHBase()
     piksi_lastfix_ccno_fp = registry.create_internal_field<unsigned int>("piksi.last_rtkfix_ccno");
     enter_close_approach_ccno_fp = registry.create_internal_field<unsigned int>("pan.enter_close_approach_ccno");
 
-    quake_power_cycle_cmd_fp = registry.create_writable_field<bool>("gomspace.power_cycle_output1_cmd");
+    quake_power_cycle_cmd_fp = registry.create_writable_field<bool>("gomspace.power_cycle_output3_cmd");
     adcs_wheel1_adc_fault_fp = registry.create_fault("adcs_monitor.wheel1_fault", 1);
     adcs_wheel2_adc_fault_fp = registry.create_fault("adcs_monitor.wheel2_fault", 1);
     adcs_wheel3_adc_fault_fp = registry.create_fault("adcs_monitor.wheel3_fault", 1);

--- a/test/test_fsw_fault_handler/test_quake_fault_handler.cpp
+++ b/test/test_fsw_fault_handler/test_quake_fault_handler.cpp
@@ -33,7 +33,7 @@ public:
     {
         radio_state_fp = registry.create_readable_field<unsigned char>("radio.state");
         last_checkin_cycle_fp = registry.create_readable_field<unsigned int>("radio.last_comms_ccno");
-        radio_power_cycle_fp = registry.create_writable_field<bool>("gomspace.power_cycle_output1_cmd");
+        radio_power_cycle_fp = registry.create_writable_field<bool>("gomspace.power_cycle_output3_cmd");
 
         // Set initial conditions
         enable_radio();

--- a/test/test_fsw_mission_manager/test_fixture.cpp
+++ b/test/test_fsw_mission_manager/test_fixture.cpp
@@ -17,7 +17,6 @@ TestFixture::TestFixture(mission_state_t initial_state) : registry()
         "orbit.baseline_pos", 0, 100000, 100);
 
     reboot_fp = registry.create_writable_field<bool>("gomspace.gs_reboot_cmd");
-    power_cycle_radio_fp = registry.create_writable_field<bool>("gomspace.power_cycle_output1_cmd");
 
     docked_fp = registry.create_readable_field<bool>("docksys.docked");
 
@@ -44,7 +43,6 @@ TestFixture::TestFixture(mission_state_t initial_state) : registry()
     prop_state_fp->set(static_cast<unsigned int>(prop_state_t::disabled));
     propagated_baseline_pos_fp->set({nan_d, nan_d, nan_d});
     reboot_fp->set(false);
-    power_cycle_radio_fp->set(false);
     docked_fp->set(false);
 
     mission_manager = std::make_unique<MissionManager>(registry, 0);

--- a/test/test_fsw_mission_manager/test_fixture.cpp
+++ b/test/test_fsw_mission_manager/test_fixture.cpp
@@ -17,6 +17,7 @@ TestFixture::TestFixture(mission_state_t initial_state) : registry()
         "orbit.baseline_pos", 0, 100000, 100);
 
     reboot_fp = registry.create_writable_field<bool>("gomspace.gs_reboot_cmd");
+    power_cycle_radio_fp = registry.create_writable_field<bool>("gomspace.power_cycle_output3_cmd");
 
     docked_fp = registry.create_readable_field<bool>("docksys.docked");
 
@@ -43,6 +44,7 @@ TestFixture::TestFixture(mission_state_t initial_state) : registry()
     prop_state_fp->set(static_cast<unsigned int>(prop_state_t::disabled));
     propagated_baseline_pos_fp->set({nan_d, nan_d, nan_d});
     reboot_fp->set(false);
+    power_cycle_radio_fp->set(false);
     docked_fp->set(false);
 
     mission_manager = std::make_unique<MissionManager>(registry, 0);

--- a/test/test_fsw_mission_manager/test_fixture.hpp
+++ b/test/test_fsw_mission_manager/test_fixture.hpp
@@ -31,6 +31,7 @@ public:
   std::shared_ptr<ReadableStateField<lin::Vector3d>> propagated_baseline_pos_fp;
 
   std::shared_ptr<WritableStateField<bool>> reboot_fp;
+  std::shared_ptr<WritableStateField<bool>> power_cycle_radio_fp;
 
   std::shared_ptr<ReadableStateField<bool>> docked_fp;
 

--- a/test/test_fsw_mission_manager/test_fixture.hpp
+++ b/test/test_fsw_mission_manager/test_fixture.hpp
@@ -31,7 +31,6 @@ public:
   std::shared_ptr<ReadableStateField<lin::Vector3d>> propagated_baseline_pos_fp;
 
   std::shared_ptr<WritableStateField<bool>> reboot_fp;
-  std::shared_ptr<WritableStateField<bool>> power_cycle_radio_fp;
 
   std::shared_ptr<ReadableStateField<bool>> docked_fp;
 


### PR DESCRIPTION
# Fixing testcase error handling

### Summary of changes
- Turns a failure condition in the QuakeFaultHandler testcase into a `TestCaseFailure`
- Update Gomspace powercycle pin for the Quake (it's output 3 not output 1).

### Testing
I reran the HOOTL case for QuakeFaultHandler. See the log [here](https://cornellprod-my.sharepoint.com/:f:/g/personal/saa243_cornell_edu/EoL_CaOdafpLp5iVL33RK3IB4F7V5jQbS53ENXKaR5sm0A?e=FaEdMh).

### Documentation Evidence
This is a very minor change that brings a PTest case towards using the established failure specification. I don't think additional documentation is necessary.
