### PR TITLE
Fix \xff on long commands HITL Bug

### DIFF
--- a/src/common/debug_console.cpp
+++ b/src/common/debug_console.cpp
@@ -181,13 +181,16 @@ void debug_console::process_commands(const StateFieldRegistry& registry) {
     if (!found_input) return;
     input.copy(buf, sizeof(buf));
 #else
-    char lastchar = '\n';
-    for (size_t i = 0; 
-    // looping condition is once there are bytes available, 
-    // keep looping while there are bytes available or the terminating char \n hasn't appeared yet
-    i < SERIAL_BUF_SIZE && (Serial.available() || lastchar != '\n'); i++) {
-        lastchar = Serial.read();
-        buf[i] = lastchar; 
+    char lastchar = '?';
+    size_t i = 0;
+    if(Serial.available()){ // if there are bytes to be processed
+        while(i < SERIAL_BUF_SIZE && lastchar != '\n'){ // loop while we are under buffer limit and we haven't seen end line
+            if(Serial.available()){ // only log to buffer if there are bytes available
+                lastchar = Serial.read();
+                buf[i] = lastchar;
+                i++;
+            }
+        }
     }
 #endif
 


### PR DESCRIPTION
# Fix \xff Bug

Fixes #534 

### Summary of changes
- Hotfix3 PR introduces a new bug where 0's dispayed as \xff in the log files will be introduced to the json commands, effectively bricking about 1% of commands written to spacecraft. The longer the command, the more likely this would occur. Discovered from detumble testing with new psim where there are many long (many bytes) commands.
-- The solution is to rewrite the loop looking for bytes to not log to buffer if no bytes are available

Problem:
![image](https://user-images.githubusercontent.com/14984742/99199721-3214a900-276f-11eb-996e-c40e1616b462.png)

### Testing
HITL tested on FC only HITL