### PR TITLE
Edit package requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ mplcursors==0.3
 numpy==1.17.2
 oauth2client==4.1.3
 packaging==19.2
-platformio==4.3.4
+platformio==5.0.3
 pluggy==0.13.0
 protobuf==3.11.3
 py==1.8.0
@@ -66,7 +66,7 @@ schema==0.7.1
 semantic-version==2.8.2
 six==1.12.0
 tabulate==0.8.5
-typed-ast==1.4.0
+typed-ast<=1.4.0
 uritemplate==3.0.1
 urllib3==1.25.7
 virtualenv==16.6.0


### PR DESCRIPTION
# Edit package requirements

Fixes ci failing builds

### Summary of changes
- bump platformio version up since old one is outdated anyway
- loosen requirements version, a quick search for "typed_ast" yields nothing in FSW, so we do not have any explicit dependencies