### PR TITLE
Removing Axios from MCT

### DIFF
--- a/MCT/package-lock.json
+++ b/MCT/package-lock.json
@@ -67,14 +67,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
-    "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "requires": {
-        "follow-redirects": "1.5.10"
-      }
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",

--- a/MCT/package.json
+++ b/MCT/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pathfinder-for-autonomous-navigation/FlightSoftware/tree/master/src/gsw"
+    "url": "git+https://github.com/pathfinder-for-autonomous-navigation/FlightSoftware/tree/master/MCT"
   },
   "author": "Kirin Kambon, Tanishq Aggarwal, and Duncan McDonald",
   "dependencies": {

--- a/MCT/package.json
+++ b/MCT/package.json
@@ -14,7 +14,6 @@
   },
   "author": "Kirin Kambon, Tanishq Aggarwal, and Duncan McDonald",
   "dependencies": {
-    "axios": "^0.19.2",
     "express": "^4.14.1",
     "express-ws": "^3.0.0",
     "openmct": "https://github.com/nasa/openmct.git",


### PR DESCRIPTION
 # Removing Axios from MCT

### Removed Axios from package.json and package-lock.json in the MCT folder due to no longer needing the dependency (request is being used instead)