### PR TITLE
Utilize Arduino's Loop Function

### DIFF
--- a/src/fsw/targets/teensy.cpp
+++ b/src/fsw/targets/teensy.cpp
@@ -12,23 +12,15 @@
 #include <core_pins.h>
 #include <wiring.h>
 
-void pan_system_setup() {
-    StateFieldRegistry registry;
-    MainControlLoop fcp(registry, PAN::flow_data);
-
-    while (true) {
-        fcp.execute();
-    }
-}
-
 // "ifndef UNIT_TEST" used to stop "multiple definition" linker errors when running
 // tests
 #ifndef UNIT_TEST
-void setup() {
-    pan_system_setup();
-    while (true)
-        ;
-}
+void setup() {}
 
-void loop() {}
+void loop() {
+    static StateFieldRegistry registry;
+    static MainControlLoop fcp(registry, PAN::flow_data);
+
+    fcp.execute();
+}
 #endif


### PR DESCRIPTION
# Utilize Arduino's Loop Function

### Summary of changes
- Update the `targets/teensy.cpp` file to move the main control loop execute calls into Arduino's `void loop(void)` function. It was discovered that the Arduino library call rely on loop being called repeatedly for certain functionality.

### Testing

Tested in HITL with a mission level testcase. Observed nominal state transitions, ADCS system initialization, etc.

### Constants
NA

### Telemetry
NA

NA