### PR TITLE
Add prop faults suppression to utils.py

### DIFF
--- a/ptest/cases/prop_fault_handler.py
+++ b/ptest/cases/prop_fault_handler.py
@@ -30,7 +30,16 @@ class PropFaultHandler(SingleSatOnlyCase):
 
     def setup_post_bootsetup(self):
         self.ws("fault_handler.enabled", True)
-        self.flight_controller.write_state("dcdc.SpikeDock_cmd", True)
+        
+        self.ws("prop.overpressured.suppress", "false")
+        self.logger.put("Releasing overpressured suppress")
+
+        self.ws("prop.tank2_temp_high.suppress", "false")
+        self.logger.put("Releasing Tank2 temp high suppress")
+
+        self.ws("prop.tank1_temp_high.suppress", "false")
+        self.logger.put("Releasing Tank1 temp high suppress")
+
         # Lower these so that we don't need to wait
         self.ws("prop.ctrl_cycles_per_filling", 1)
         self.ws("prop.ctrl_cycles_per_cooling", 2)

--- a/ptest/cases/safehold_standby_transition_case.py
+++ b/ptest/cases/safehold_standby_transition_case.py
@@ -135,7 +135,7 @@ class SafeholdStandbyTransitionCase(SingleSatOnlyCase):
         self.firstSafehold = False
       else:
         if currCycle - self.tempTime < 20:
-          #do nothing
+          # about 3.4 seconds with sped up FSW (170 ms cc)
           pass
         else:
           self.logger.put("supressing wheel 1 fault")

--- a/ptest/cases/safehold_standby_transition_case.py
+++ b/ptest/cases/safehold_standby_transition_case.py
@@ -134,7 +134,7 @@ class SafeholdStandbyTransitionCase(SingleSatOnlyCase):
         self.tempTime = currCycle
         self.firstSafehold = False
       else:
-        if currCycle - self.tempTime < 70:
+        if currCycle - self.tempTime < 20:
           #do nothing
           pass
         else:

--- a/ptest/cases/utils.py
+++ b/ptest/cases/utils.py
@@ -280,6 +280,16 @@ class BootUtil(object):
             self.flight_controller.write_state("fault_handler.enabled", "false")
             self.logger.put("Turning off fault_handler")
 
+            # Suppress Prop Faults
+            self.flight_controller.write_state("prop.overpressured.suppress", "true")
+            self.logger.put("Turning off overpressued suppress")
+
+            self.flight_controller.write_state("prop.tank2_temp_high.suppress", "true")
+            self.logger.put("Tank2 temp high suppress")
+
+            self.flight_controller.write_state("prop.tank1_temp_high.suppress", "true")
+            self.logger.put("Suppressing Tank1 temp high")
+    
             # Prevent ADCS faults from causing transition to initialization hold
             self.flight_controller.write_state("adcs_monitor.functional_fault.suppress", "true")
             self.logger.put("Suppressing adcs_monitor.functional_fault")

--- a/ptest/cases/utils.py
+++ b/ptest/cases/utils.py
@@ -282,10 +282,10 @@ class BootUtil(object):
 
             # Suppress Prop Faults
             self.flight_controller.write_state("prop.overpressured.suppress", "true")
-            self.logger.put("Turning off overpressued suppress")
+            self.logger.put("Suppressing turning off overpressued")
 
             self.flight_controller.write_state("prop.tank2_temp_high.suppress", "true")
-            self.logger.put("Tank2 temp high suppress")
+            self.logger.put("Suppressing Tank2 temp high ")
 
             self.flight_controller.write_state("prop.tank1_temp_high.suppress", "true")
             self.logger.put("Suppressing Tank1 temp high")


### PR DESCRIPTION
# Add prop faults suppression to utils.py

Prevents prop valves from firing in EDU HITL cases.

### Summary of changes
- Add suppression of prop faults to default utils.py boot utility
- Decreased safehold time to prevent safehold timeout
