### PR TITLE
Move ADCS DCDC Control Logic to Mission Manager

### DIFF
--- a/src/fsw/FCCode/ADCSBoxController.cpp
+++ b/src/fsw/FCCode/ADCSBoxController.cpp
@@ -11,7 +11,6 @@ ADCSBoxController::ADCSBoxController(StateFieldRegistry &registry,
     {
         //find command statefields
         adcs_state_fp = find_writable_field<unsigned char>("adcs.state", __FILE__, __LINE__);
-        adcs_dcdc_fp = find_writable_field<bool>("dcdc.ADCSMotor_cmd", __FILE__, __LINE__);
 
         rwa_mode_fp = find_writable_field<unsigned char>("adcs_cmd.rwa_mode", __FILE__, __LINE__);
         rwa_speed_cmd_fp = find_writable_field<f_vector_t>("adcs_cmd.rwa_speed_cmd", __FILE__, __LINE__);

--- a/src/fsw/FCCode/ADCSBoxController.cpp
+++ b/src/fsw/FCCode/ADCSBoxController.cpp
@@ -58,11 +58,9 @@ void ADCSBoxController::execute(){
     // set to passive/disabled if in startup
     if(adcs_state_fp->get() == static_cast<unsigned char>(adcs_state_t::startup)) {
         adcs_system.set_mode(adcs::ADCSMode::ADCS_PASSIVE);
-        adcs_dcdc_fp->set(false);
     }
     else {
         adcs_system.set_mode(adcs::ADCSMode::ADCS_ACTIVE);
-        adcs_dcdc_fp->set(true);
     }
 
     // dump all commands

--- a/src/fsw/FCCode/ADCSBoxController.hpp
+++ b/src/fsw/FCCode/ADCSBoxController.hpp
@@ -37,11 +37,6 @@ protected:
     const WritableStateField<unsigned char>* adcs_state_fp;
 
     /**
-     * @brief DCDC control. Disables/enables wheels.
-     */
-    WritableStateField<bool>* adcs_dcdc_fp;
-
-    /**
      * @brief RWA command fields
      * 
      */

--- a/src/fsw/FCCode/MissionManager.cpp
+++ b/src/fsw/FCCode/MissionManager.cpp
@@ -209,9 +209,10 @@ void MissionManager::dispatch_detumble()
 
     if (momentum <= threshold * threshold) // Save a sqrt call and use fro norm
     {
-        transition_to(mission_state_t::standby,
-                      adcs_state_t::point_standby);
-        adcs_dcdc_fp->set(true);
+        if(!adcs_dcdc_fp->get()) // cause a cycle where DCDC is turned on then wheels turn on
+            adcs_dcdc_fp->set(true);
+        else
+            transition_to(mission_state_t::standby, adcs_state_t::point_standby);
     }
 }
 
@@ -313,7 +314,7 @@ void MissionManager::dispatch_docking()
         have_set_docking_entry_ccno = false;
         transition_to(mission_state_t::standby,
                       adcs_state_t::point_standby);
-        adcs_dcdc_fp->set(true);
+        // ADCS dcdc should already be on, no need to re-assert
     }
 }
 

--- a/src/fsw/FCCode/MissionManager.cpp
+++ b/src/fsw/FCCode/MissionManager.cpp
@@ -406,13 +406,6 @@ void MissionManager::transition_to(mission_state_t mission_state,
         sph_dcdc_fp->set(true);
     }
 
-    if (mission_state == mission_state_t::standby)
-        adcs_dcdc_fp->set(true);
-    else if(mission_state == mission_state_t::safehold)
-        adcs_dcdc_fp->set(false);
-    // all other transitions shall leave the DCDC's alone
-
-    set(mission_state);
-    set(adcs_state);
+    transition_to(mission_state, adcs_state);
     set(prop_state);
 }

--- a/src/fsw/FCCode/MissionManager.cpp
+++ b/src/fsw/FCCode/MissionManager.cpp
@@ -110,6 +110,7 @@ void MissionManager::execute()
             && state != mission_state_t::standby)
         {
             transition_to(mission_state_t::standby, adcs_state_t::point_standby);
+            adcs_dcdc_fp->set(true);
             return;
         }
     }
@@ -311,7 +312,8 @@ void MissionManager::dispatch_docking()
     {
         have_set_docking_entry_ccno = false;
         transition_to(mission_state_t::standby,
-                      adcs_state_t::startup);
+                      adcs_state_t::point_standby);
+        adcs_dcdc_fp->set(true);
     }
 }
 

--- a/src/fsw/FCCode/MissionManager.cpp
+++ b/src/fsw/FCCode/MissionManager.cpp
@@ -383,10 +383,10 @@ void MissionManager::set(sat_designation_t designation)
 void MissionManager::transition_to(mission_state_t mission_state,
                                    adcs_state_t adcs_state)
 {
-    if (mission_state == mission_state_t::standby)
-        adcs_dcdc_fp->set(true);
-    else if(mission_state == mission_state_t::safehold)
+   if (mission_state == mission_state_t::safehold)
+   {
         adcs_dcdc_fp->set(false);
+    }
     // all other transitions shall leave the DCDC's alone
 
     set(mission_state);

--- a/src/fsw/FCCode/MissionManager.cpp
+++ b/src/fsw/FCCode/MissionManager.cpp
@@ -71,6 +71,7 @@ MissionManager::MissionManager(StateFieldRegistry &registry, unsigned int offset
     pressurize_fail_fp = find_fault("prop.pressurize_fail.base", __FILE__, __LINE__);
 
     sph_dcdc_fp = find_writable_field<bool>("dcdc.SpikeDock_cmd", __FILE__, __LINE__);
+    adcs_dcdc_fp = find_writable_field<bool>("dcdc.ADCSMotor_cmd", __FILE__, __LINE__);
 
     // Initialize a bunch of variables
     detumble_safety_factor_f.set(initial_detumble_safety_factor);
@@ -99,6 +100,7 @@ void MissionManager::execute()
         if (fault_response == fault_response_t::safehold)
         {
             transition_to(mission_state_t::safehold, adcs_state_t::startup, prop_state_t::disabled);
+            adcs_dcdc_fp->set(false);
             return;
         }
         else if (fault_response == fault_response_t::standby
@@ -154,6 +156,7 @@ void MissionManager::execute()
     default:
         printf(debug_severity::error, "Master state not defined: %d\n", static_cast<unsigned char>(state));
         transition_to(mission_state_t::safehold, adcs_state_t::startup);
+        adcs_dcdc_fp->set(false);
         break;
     }
 }
@@ -207,6 +210,7 @@ void MissionManager::dispatch_detumble()
     {
         transition_to(mission_state_t::standby,
                       adcs_state_t::point_standby);
+        adcs_dcdc_fp->set(true);
     }
 }
 

--- a/src/fsw/FCCode/MissionManager.hpp
+++ b/src/fsw/FCCode/MissionManager.hpp
@@ -159,6 +159,11 @@ protected:
     WritableStateField<bool> *sph_dcdc_fp;
 
     /**
+     * @brief DCDC control Disables/enables wheels for the ADCS system.
+     */
+    WritableStateField<bool>* adcs_dcdc_fp;
+
+    /**
      * @brief Radio's mode.
      **/
     ReadableStateField<unsigned char> *radio_state_fp;

--- a/test/test_fsw_mission_manager/test_fixture.cpp
+++ b/test/test_fsw_mission_manager/test_fixture.cpp
@@ -35,6 +35,7 @@ TestFixture::TestFixture(mission_state_t initial_state, unsigned int bootcount) 
     overpressured_fp = registry.create_fault("prop.overpressured", 1);
 
     sph_dcdc_fp = registry.create_writable_field<bool>("dcdc.SpikeDock_cmd");
+    adcs_dcdc_fp = registry.create_writable_field<bool>("dcdc.ADCSMotor_cmd");
 
     piksi_state_fp = registry.create_readable_field<unsigned char>("piksi.state");
     last_rtkfix_ccno_fp = registry.create_internal_field<unsigned int>("piksi.last_rtkfix_ccno");

--- a/test/test_fsw_mission_manager/test_fixture.cpp
+++ b/test/test_fsw_mission_manager/test_fixture.cpp
@@ -142,6 +142,11 @@ void TestFixture::check_sph_dcdc_on(bool on) const
     TEST_ASSERT(sph_dcdc_fp->get() == on);
 }
 
+void TestFixture::check_adcs_dcdc_on(bool on) const
+{
+    TEST_ASSERT(adcs_dcdc_fp->get() == on);
+}
+
 // Ensures that no state except the given state can be achieved.
 void TestFixture::assert_ground_uncommandability(adcs_state_t exception_state)
 {

--- a/test/test_fsw_mission_manager/test_fixture.hpp
+++ b/test/test_fsw_mission_manager/test_fixture.hpp
@@ -82,6 +82,7 @@ public:
 
   // Check if the SpikeDoc DCDC pin is on or off.
   void check_sph_dcdc_on(bool on) const;
+  void check_adcs_dcdc_on(bool on) const;
 
   // Containers for enum possibilities
   static adcs_state_t adcs_states[9];

--- a/test/test_fsw_mission_manager/test_fixture.hpp
+++ b/test/test_fsw_mission_manager/test_fixture.hpp
@@ -45,6 +45,7 @@ public:
   std::shared_ptr<Fault> overpressured_fp;
 
   std::shared_ptr<WritableStateField<bool>> sph_dcdc_fp;
+  std::shared_ptr<WritableStateField<bool>> adcs_dcdc_fp;
 
   std::shared_ptr<ReadableStateField<unsigned char>> piksi_state_fp;
   std::shared_ptr<InternalStateField<unsigned int>> last_rtkfix_ccno_fp;

--- a/test/test_fsw_mission_manager/test_mission_manager.cpp
+++ b/test/test_fsw_mission_manager/test_mission_manager.cpp
@@ -239,6 +239,7 @@ void test_dispatch_safehold() {
     {
         TestFixture tf(mission_state_t::safehold);
         tf.check_sph_dcdc_on(false);
+        tf.check_adcs_dcdc_on(false);
 
         // Below one day's worth of cycle counts, safe hold should
         // not trigger a satellite reboot.
@@ -281,6 +282,7 @@ void test_dispatch_undefined() {
     tf.mission_state_fp->set(100); // Undefined
     tf.step();
     tf.check(mission_state_t::safehold);
+    tf.check_adcs_dcdc_on(false);
 }
 
 void test_fault_responses() {

--- a/test/test_fsw_mission_manager/test_mission_manager.cpp
+++ b/test/test_fsw_mission_manager/test_mission_manager.cpp
@@ -87,11 +87,20 @@ void test_dispatch_detumble() {
     // If satellite is no longer tumbling, spacecraft exits detumble mode
     // and starts pointing in the expected direction.
     tf.set_ang_rate(threshold - delta);
+    tf.check_adcs_dcdc_on(false);
+    
+    // check that the ADCS DCDC is turned on pre-emptively but mission mode stays in detumble
+    tf.step();
+    tf.check_adcs_dcdc_on(true);
+    tf.check(mission_state_t::detumble);
+
+    // check that the second time around the mission mode does transition
     tf.step();
     tf.check(adcs_state_t::point_standby);
     tf.check(mission_state_t::standby);
     // TODO
     tf.check_sph_dcdc_on(true);
+    tf.check_adcs_dcdc_on(true);
 }
 
 void test_dispatch_standby() {
@@ -341,14 +350,18 @@ void test_fault_responses() {
                                          mission_state_t::docked})
     {
         TestFixture tf{initial_state};
+        tf.adcs_dcdc_fp->set(true);
         tf.set(fault_response_t::standby);
         tf.step();
         tf.check(mission_state_t::standby);
+        tf.check_adcs_dcdc_on(true);
 
         TestFixture tf2{initial_state};
+        tf.adcs_dcdc_fp->set(true);
         tf2.set(fault_response_t::safehold);
         tf2.step();
         tf2.check(mission_state_t::safehold);
+        tf2.check_adcs_dcdc_on(false);
     }
 }
 


### PR DESCRIPTION
# Move ADCS DCDC Control Logic to Mission Manager

Fixes DCDC Checkout Case failures
- Also allows ADCS DCDC to be off during detumble (until the last cycle)

### Summary of changes
- DCDC is enabled in the last cycle of detumble, then it transitions to standby happens on the next cycle
- Now all test cases will be in detumble twice
- Updated unit tests to reflect ADCS DCDC being turned off on faults into safehold

### Testing
- TODO