### PR TITLE
Fix DCDC Checkout Case

### DIFF
--- a/ptest/cases/dcdc_checkout_case.py
+++ b/ptest/cases/dcdc_checkout_case.py
@@ -111,7 +111,7 @@ class DCDCCheckoutCase(SingleSatOnlyCase):
             self.logger.put("Testcase initialized correctly.")
             self.logger.put("")
 
-        self.logger.put("Step 1: Set both DCDCs to on...")
+        self.logger.put("Step 1: Enable both DCDCs...")
 
         self.adcs_command = True
         self.prop_command = True
@@ -149,7 +149,7 @@ class DCDCCheckoutCase(SingleSatOnlyCase):
         self.logger.put("Success!")
         self.logger.put("")
 
-        self.logger.put("Step 4: Disabled both DCDCs and attempt a reset command...")
+        self.logger.put("Step 4: Disable both DCDCs and attempt a reset command...")
 
         self.disable_command = True
         self.cycle()

--- a/ptest/cases/dcdc_checkout_case.py
+++ b/ptest/cases/dcdc_checkout_case.py
@@ -1,120 +1,168 @@
 from .base import SingleSatOnlyCase
+from .utils import Enums, TestCaseFailure
 
 class DCDCCheckoutCase(SingleSatOnlyCase):
-    @property
-    def adcs_cmd(self): 
-        return self.flight_controller.read_state("dcdc.ADCSMotor_cmd")
+
+    def __init__(self, *args, **kwargs):
+        super(DCDCCheckoutCase, self).__init__(*args, **kwargs)
+
+        self.__adcs_command = None
+        self.__adcs = None
+        self.__prop_command = None
+        self.__prop = None
+        self.__disable_command = None
+        self.__reset_command = None
 
     @property
-    def sph_cmd(self): 
-        return self.flight_controller.read_state("dcdc.SpikeDock_cmd")
-    
-    @property
-    def disable_cmd(self): 
-        return self.flight_controller.read_state("dcdc.disable_cmd")
+    def adcs_command(self) -> bool:
+        assert self.__adcs_command is not None
+        return self.__adcs_command
+
+    @adcs_command.setter
+    def adcs_command(self, value: bool):
+        self.ws("dcdc.ADCSMotor_cmd", value)
 
     @property
-    def reset_cmd(self): 
-        return self.flight_controller.read_state("dcdc.reset_cmd")
+    def adcs(self) -> bool:
+        assert self.__adcs is not None
+        return self.__adcs
 
     @property
-    def adcs_rd(self): 
-        return self.flight_controller.read_state("dcdc.ADCSMotor")
-    
+    def prop_command(self) -> bool:
+        assert self.__prop_command is not None
+        return self.__prop_command
+
+    @prop_command.setter
+    def prop_command(self, value: bool):
+        self.ws("dcdc.SpikeDock_cmd", value)
+
     @property
-    def sph_rd(self): 
-        return self.flight_controller.read_state("dcdc.SpikeDock")
+    def prop(self) -> bool:
+        assert self.__prop is not None
+        return self.__prop
 
-    @adcs_cmd.setter 
-    def adcs_cmd(self, value): 
-        assert(value == "true" or value == "false")
-        self.flight_controller.write_state("dcdc.ADCSMotor_cmd", value)
+    @property
+    def disable_command(self) -> bool:
+        assert self.__disable_command is not None
+        return self.__disable_command
 
-    @sph_cmd.setter 
-    def sph_cmd(self, value): 
-        assert(value == "true" or value == "false")
-        self.flight_controller.write_state("dcdc.SpikeDock_cmd", value)
+    @disable_command.setter
+    def disable_command(self, value: bool):
+        self.ws("dcdc.disable_cmd", value)
 
-    @disable_cmd.setter 
-    def disable_cmd(self, value): 
-        assert(value == "true" or value == "false")
-        self.flight_controller.write_state("dcdc.disable_cmd", value)
+    @property
+    def reset_command(self) -> bool:
+        assert self.__reset_command is not None
+        return self.__reset_command
 
-    @reset_cmd.setter 
-    def reset_cmd(self, value): 
-        assert(value == "true" or value == "false")
-        self.flight_controller.write_state("dcdc.reset_cmd", value)
+    @reset_command.setter
+    def reset_command(self, value: bool):
+        self.ws("dcdc.reset_cmd", value)
+
+    def cycle(self):
+        super(DCDCCheckoutCase, self).cycle()
+
+        self.__adcs_command = self.rs("dcdc.ADCSMotor_cmd")
+        self.__adcs = self.rs("dcdc.ADCSMotor")
+        self.__prop_command = self.rs("dcdc.SpikeDock_cmd")
+        self.__prop = self.rs("dcdc.SpikeDock")
+        self.__disable_command = self.rs("dcdc.disable_cmd")
+        self.__reset_command = self.rs("dcdc.reset_cmd")
 
     def run_case_singlesat(self):
-        self.cycle_no = self.flight_controller.read_state("pan.cycle_no")
 
-        if self.adcs_cmd==self.adcs_rd and self.sph_cmd==self.sph_rd and self.disable_cmd=="false" and self.reset_cmd=="false":
-            self.logger.put("Control task initialized correctly") 
+        def abort(*args, **kwargs):
+            self.logger.put(f"Testcase failed:")
+            self.logger.put(f"\tadcs_command   = {self.adcs_command}")
+            self.logger.put(f"\tadcs           = {self.adcs}")
+            self.logger.put(f"\tprop_command   = {self.prop_command}")
+            self.logger.put(f"\tprop           = {self.prop}")
+            self.logger.put(f"\tdisable_command = {self.disable_command}")
+            self.logger.put(f"\treset_command   = {self.reset_command}")
 
-        print ("Test case 1: Try both DCDCs on. Turn on all systems (ADCS motors, prop valves, docking motor).")
-
-        self.adcs_cmd="true"
-        self.sph_cmd="true"
-
-        if self.adcs_rd=="true" and self.sph_rd=="true":
-            self.logger.put("Passed")
-        else:
-            self.logger.put("Failed")
-
-        self.logger.put("Test case 2: ADCS DCDC on, SPH + Prop DCDC off. Turn on all systems.")
-
-        self.adcs_cmd="true"
-        self.sph_cmd="false"
-        if self.adcs_rd=="true" and self.sph_rd=="false":
-            self.reset_cmd="true"
-            # Reset takes at least one control cycle to complete
+            self.adcs_command = False
+            self.prop_command = False
             self.cycle()
-            if (self.adcs_rd == "true" and self.sph_rd == "true"):
-                self.logger.put("Passed")
-            else:
-                self.logger.put("Unable to reset pins")
-                self.logger.put("ADCS Motor pin: "+self.adcs_rd)
-                self.logger.put("Spike and Hold pin: "+self.sph_rd)
-        else:
-            self.logger.put("Unable to turn ADCS Motor on and SpikeDock off")
-            self.logger.put("ADCS Motor pin: "+self.adcs_rd)
-            self.logger.put("Spike and Hold pin: "+self.sph_rd)
 
-        self.logger.put("Test Case 3: ADCS DCDC off, SPH + Prop DCDC on. Turn on all systems. ")
+            raise TestCaseFailure(*args, **kwargs)
 
-        self.adcs_cmd="false"
-        self.sph_cmd="true"
-        if self.adcs_rd=="false" and self.sph_rd=="true":
-            self.reset_cmd="true"
-            # Reset takes at least one control cycle to complete
+        def reset(has_enabled = True):
+            self.reset_command = True
             self.cycle()
-            if (self.adcs_rd == "true" and self.sph_rd == "true"):
-                self.logger.put("Passed")
-            else:
-                self.logger.put("Unable to reset pins")
-                self.logger.put("ADCS Motor pin: "+self.adcs_rd)
-                self.logger.put("Spike and Hold pin: "+self.sph_rd)
-        else:
-            self.logger.put("Unable to turn ADCS Motor off and SpikeDock on")
-            self.logger.put("ADCS Motor pin: "+self.adcs_rd)
-            self.logger.put("Spike and Hold pin: "+self.sph_rd)
 
-        self.logger.put("Test Case 4: ADCS DCDC off, SPH + Prop DCDC off. Turn on all systems. ")
+            if has_enabled:
+                if not self.reset_command:
+                    abort("Reset command should persist for one cycle is some elements are enabled.")
 
-        self.disable_cmd="true"
-        if self.adcs_rd=="false" and self.sph_rd=="false":
-            self.reset_cmd="true"
-            # Reset takes at least one control cycle to complete
-            self.cycle()
-            if (self.adcs_rd == "true" and self.sph_rd == "true"):
-                self.logger.put("Passed")
-            else:
-                self.logger.put("Unable to reset pins")
-                self.logger.put("ADCS Motor pin: "+self.adcs_rd)
-                self.logger.put("Spike and Hold pin: "+self.sph_rd)
+                self.cycle()
+
+            if not self.adcs_command or not self.adcs or \
+                    not self.prop_command or not self.prop or self.reset_command:
+               abort("Failed to reset the DCDCs.")
+
+        self.ws("pan.state", Enums.mission_states["manual"])
+        self.cycle()
+
+        if self.adcs_command or self.adcs or self.prop or self.prop_command or \
+                self.disable_command or self.reset_command:
+            abort("All fields should be false on initialization; " +
+                  "ensure the spacecraft was rebooted before running this case.")
         else:
-            self.logger.put("Unable to disable pins")
-            self.logger.put("ADCS Motor pin: "+self.adcs_rd)
-            self.logger.put("Spike and Hold pin: "+self.sph_rd)
+            self.logger.put("Testcase initialized correctly.")
+            self.logger.put("")
+
+        self.logger.put("Step 1: Set both DCDCs to on...")
+
+        self.adcs_command = True
+        self.prop_command = True
+        self.cycle()
+
+        if self.adcs_command and self.adcs and self.prop_command and self.prop:
+            self.logger.put("Success!")
+        else:
+            abort("Failed to enable both DCDCs.")
+
+        self.logger.put("")
+        self.logger.put("Step 2: Set only ADCS to be on and then attempt a reset command...")
+
+        self.adcs_command = True
+        self.prop_command = False
+        self.cycle()
+
+        if not self.adcs_command or not self.adcs or self.prop_command or self.prop:
+            abort("Failed to enable only the ADCS DCDC.")
+        
+        reset()
+        self.logger.put("Success!")
+        self.logger.put("")
+
+        self.logger.put("Step 3: Enable only Prop to be on and then attempt a reset command...")
+
+        self.adcs_command = False
+        self.prop_command = True
+        self.cycle()
+
+        if self.adcs_command or self.adcs or not self.prop or not self.prop_command:
+            abort("Failed to enable only the Prop DCDC.")
+        
+        reset()
+        self.logger.put("Success!")
+        self.logger.put("")
+
+        self.logger.put("Step 4: Disabled both DCDCs and attempt a reset command...")
+
+        self.disable_command = True
+        self.cycle()
+
+        if self.adcs_command or self.adcs or self.prop_command or self.prop or self.disable_command:
+            abort("Failed to disable the DCDCs.")
+        
+        reset(False)
+        self.logger.put("Success!")
+        self.logger.put("")
+
+        self.adcs_command = False
+        self.prop_command = False
+        self.cycle()
 
         self.finish()

--- a/ptest/cases/dcdc_checkout_case.py
+++ b/ptest/cases/dcdc_checkout_case.py
@@ -60,6 +60,9 @@ class DCDCCheckoutCase(SingleSatOnlyCase):
         self.ws("dcdc.reset_cmd", value)
 
     def abort(self, *args, **kwargs):
+        """Logs a table of the current DCDC state fields to the terminal,
+        attempts to shutdown the DCDCs, and raises a TestCaseFailure.
+        """
         self.logger.put(f"Testcase failed:")
         self.logger.put(f"\tadcs_command    = {self.adcs_command}")
         self.logger.put(f"\tadcs            = {self.adcs}")
@@ -75,6 +78,12 @@ class DCDCCheckoutCase(SingleSatOnlyCase):
         raise TestCaseFailure(*args, **kwargs)
 
     def cycle(self):
+        """Cycles the flight computer and reads in all DCDC state fields.
+
+        All DCDC reads are performed here to avoid extra overhead from duplicate
+        read state calls. In addition, it makes implementing the very useful
+        abort function trivial.
+        """
         super(DCDCCheckoutCase, self).cycle()
 
         self.__adcs_command = self.rs("dcdc.ADCSMotor_cmd")
@@ -85,6 +94,8 @@ class DCDCCheckoutCase(SingleSatOnlyCase):
         self.__reset_command = self.rs("dcdc.reset_cmd")
 
     def reset(self, has_enabled = True):
+        """Runs and verifies the DCDC reset command executes as expected.
+        """
         self.reset_command = True
         self.cycle()
 

--- a/ptest/cases/dcdc_checkout_case.py
+++ b/ptest/cases/dcdc_checkout_case.py
@@ -131,7 +131,7 @@ class DCDCCheckoutCase(SingleSatOnlyCase):
 
         if not self.adcs_command or not self.adcs or self.prop_command or self.prop:
             abort("Failed to enable only the ADCS DCDC.")
-        
+
         reset()
         self.logger.put("Success!")
         self.logger.put("")
@@ -144,7 +144,7 @@ class DCDCCheckoutCase(SingleSatOnlyCase):
 
         if self.adcs_command or self.adcs or not self.prop or not self.prop_command:
             abort("Failed to enable only the Prop DCDC.")
-        
+
         reset()
         self.logger.put("Success!")
         self.logger.put("")
@@ -156,7 +156,7 @@ class DCDCCheckoutCase(SingleSatOnlyCase):
 
         if self.adcs_command or self.adcs or self.prop_command or self.prop or self.disable_command:
             abort("Failed to disable the DCDCs.")
-        
+
         reset(False)
         self.logger.put("Success!")
         self.logger.put("")

--- a/src/fsw/FCCode/DCDCController.cpp
+++ b/src/fsw/FCCode/DCDCController.cpp
@@ -42,11 +42,15 @@ void DCDCController::execute() {
         dcdc.disable_sph();
     }
 
-    if (disable_cmd_f.get() && (dcdc.adcs_enabled() || dcdc.sph_enabled())) {
-        dcdc.disable();
-        // Set commands to false to prevent unwanted writes on the next cycle
-        ADCSMotorDCDC_cmd_f.set(false);
-        SpikeDockDCDC_cmd_f.set(false);
+    if (disable_cmd_f.get()) {
+        if (dcdc.adcs_enabled() || dcdc.sph_enabled()) {
+            dcdc.disable();
+            // Set commands to false to prevent unwanted writes on the next cycle
+            ADCSMotorDCDC_cmd_f.set(false);
+            SpikeDockDCDC_cmd_f.set(false);
+        }
+        // Whether or not action was taken, we don't want the disable command to
+        // persist across control cycles
         disable_cmd_f.set(false);
     }
 

--- a/test/test_fsw_dcdc/test_fsw_dcdc.cpp
+++ b/test/test_fsw_dcdc/test_fsw_dcdc.cpp
@@ -52,21 +52,29 @@ void test_task_execute() {
     tf.dcdc_controller->execute();
     TEST_ASSERT_EQUAL(true, tf.dcdc.adcs_enabled());
     TEST_ASSERT_EQUAL(true, tf.dcdc.sph_enabled());
+    TEST_ASSERT_EQUAL(true, tf.ADCSMotorDCDC_cmd_fp->get());
+    TEST_ASSERT_EQUAL(true, tf.SpikeDockDCDC_fp->get());
 
     tf.ADCSMotorDCDC_cmd_fp->set(false);
     tf.SpikeDockDCDC_cmd_fp->set(false);
     tf.dcdc_controller->execute();
     TEST_ASSERT_EQUAL(false, tf.dcdc.adcs_enabled());
+    TEST_ASSERT_EQUAL(false, tf.ADCSMotorDCDC_cmd_fp->get());
+    TEST_ASSERT_EQUAL(false, tf.SpikeDockDCDC_fp->get());
     TEST_ASSERT_EQUAL(false, tf.dcdc.sph_enabled());
 
     // Test the disable command
     tf.ADCSMotorDCDC_cmd_fp->set(true);
     tf.SpikeDockDCDC_cmd_fp->set(true);
+    tf.dcdc_controller->execute();
 
     tf.disable_cmd_fp->set(true);
     tf.dcdc_controller->execute();
     TEST_ASSERT_EQUAL(false, tf.dcdc.adcs_enabled());
     TEST_ASSERT_EQUAL(false, tf.dcdc.sph_enabled());
+    TEST_ASSERT_EQUAL(false, tf.ADCSMotorDCDC_cmd_fp->get());
+    TEST_ASSERT_EQUAL(false, tf.SpikeDockDCDC_fp->get());
+    TEST_ASSERT_EQUAL(false, tf.disable_cmd_fp->get());
 
     // If one pin is truned off and the other is on, then disable()
     // should still turn both pins off
@@ -91,6 +99,16 @@ void test_task_execute() {
     tf.dcdc_controller->execute();
     TEST_ASSERT_EQUAL(false, tf.dcdc.adcs_enabled());
     TEST_ASSERT_EQUAL(false, tf.dcdc.sph_enabled());
+
+    // The disable command shouldn't persist across control cycles if the DCDCs
+    // are already disable
+    tf.ADCSMotorDCDC_cmd_fp->set(false);
+    tf.SpikeDockDCDC_cmd_fp->set(false);
+    tf.dcdc_controller->execute();
+
+    tf.disable_cmd_fp->set(true);
+    tf.dcdc_controller->execute();
+    TEST_ASSERT_EQUAL(false, tf.disable_cmd_fp->get());
 
     // Test the reset command
     tf.ADCSMotorDCDC_cmd_fp->set(true);


### PR DESCRIPTION
# Fix DCDC Checkout Case

Relates to #573.
Requires #642.

### Summary of changes

- Update the DCDC checkout case to have stricter checks on behavior, increase verbosity of error messages, use testcase failure, and other general improvements.
- Remove persistence of the `dcdc.disable_cmd` field.

### Testing

Passed the DCDC checkout case in HITL:

```
@thinkpad ~/git/pan/fsw git:(bugfix/dcdc-checkout) venv:(3.9.1)
% python -m ptest runsim -c ptest/configs/hitl_singlesat.json -t DCDCCheckoutCase -ni
 _______     _       ____  _____                                
|_   __ \   / \     |_   \|_   _|                            
  | |__) | / _ \      |   \ | |                               
  |  ___/ / ___ \     | |\ \| |                              
 _| |_  _/ /   \ \_  _| |_\   |_                             
|_____||____| |____||_____|\____|                              
                                                                
Pathfinder for Autonomous Navigation                            
Space Systems Design Studio, Cornell University       
Console Software | Version 1.0

terminate called after throwing an instance of 'nlohmann::detail::parse_error'
  what():  [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal
terminate called after throwing an instance of 'nlohmann::detail::parse_error'
  what():  [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal
Opened connection to FlightController.
FlightController HTTP command endpoint is running at http://localhost:8000
Running mission testcase DCDCCheckoutCase.
[TESTCASE] Starting testcase.
[TESTCASE] Suppressing Faults!
Suppressing gomspace.low_batt
Turning off fault_handler
Suppressing turning off overpressued
Suppressing Tank2 temp high 
Suppressing Tank1 temp high
Suppressing adcs_monitor.functional_fault
Suppressing adcs_monitor.wheel1_fault
Suppressing adcs_monitor.wheel2_fault
Suppressing adcs_monitor.wheel3_fault
Suppressing adcs_monitor.wheel_pot_fault
Waiting for the satellite to boot to manual.
[TESTCASE] Fast Boot: Setting MissionMode to manual state.
Testcase initialized correctly.

Step 1: Set both DCDCs to on...
Success!

Step 2: Set only ADCS to be on and then attempt a reset command...
Success!

Step 3: Enable only Prop to be on and then attempt a reset command...
Success!

Step 4: Disable both DCDCs and attempt a reset command...
Success!

[TESTCASE] Finished testcase.
Exiting since user requested non-interactive execution.
Stopping binary monitor thread...
Stopping uplink console...
Terminating 0 radio connection(s)...
Terminating 1 device connection(s)...
 - Terminating console connection to and saving logging/telemetry data for FlightController.
```

### Constants

NA

### Telemetry

NA

### Documentation Evidence

Post to ReadTheDocs, or
- Argue that your inline documentation is sufficient.
- Create a issue ticket deferring the documentation task.
