### PR TITLE
Time and Orbit Estimator Control Tasks

### DIFF
--- a/src/fsw/FCCode/FieldCreatorTask.hpp
+++ b/src/fsw/FCCode/FieldCreatorTask.hpp
@@ -15,7 +15,6 @@
 // eventually become zero.
 class FieldCreatorTask : public ControlTask<void> {
     public:
-      ReadableStateField<double> time_f;
       ReadableStateField<lin::Vector3d> pos_f;
       ReadableStateField<lin::Vector3d> vel_f;
       ReadableStateField<lin::Vector3d> pos_baseline_f;
@@ -24,7 +23,6 @@ class FieldCreatorTask : public ControlTask<void> {
 
       FieldCreatorTask(StateFieldRegistry& r) : 
         ControlTask<void>(r),
-        time_f("orbit.time", Serializer<double>(0.0, 18'446'744'073'709'551'616.0, 64)),
         pos_f("orbit.pos", Serializer<lin::Vector3d>(6771000, 6921000, 28)),
         vel_f("orbit.vel", Serializer<lin::Vector3d>(7570, 7685, 19)),
         pos_baseline_f("orbit.baseline_pos", Serializer<lin::Vector3d>(0,2000,22)),
@@ -32,7 +30,6 @@ class FieldCreatorTask : public ControlTask<void> {
         bootcount_f("pan.bootcount",Serializer<unsigned int>(0xfffffff), 1000)
       {
           // For OrbitController
-          add_readable_field(time_f); // Time since the PAN epoch in seconds
           add_readable_field(pos_f);
           add_readable_field(vel_f);
           add_readable_field(pos_baseline_f);

--- a/src/fsw/FCCode/MainControlLoop.cpp
+++ b/src/fsw/FCCode/MainControlLoop.cpp
@@ -30,6 +30,8 @@ MainControlLoop::MainControlLoop(StateFieldRegistry& registry,
       ADCS_INITIALIZATION,
       adcs_monitor(registry, adcs_monitor_offset, adcs),
       debug_task(registry, debug_task_offset),
+      time_estimator(registry, time_estimator_offset),
+      orbit_estimator(registry, orbit_estimator_offset),
       attitude_estimator(registry, attitude_estimator_offset),
       gomspace(&hk, &config, &config2),
       gomspace_controller(registry, gomspace_controller_offset, gomspace),
@@ -111,6 +113,8 @@ void MainControlLoop::execute() {
     #endif
 
     uplink_consumer.execute_on_time();
+    time_estimator.execute_on_time();
+    orbit_estimator.execute_on_time();
     attitude_estimator.execute_on_time();
     mission_manager.execute_on_time();
     dcdc_controller.execute_on_time();
@@ -122,7 +126,7 @@ void MainControlLoop::execute() {
     downlink_producer.execute_on_time();
     quake_manager.execute_on_time();
     docking_controller.execute_on_time();
-    
+
     #ifdef DESKTOP
         eeprom_controller.execute_on_time();
     #else

--- a/src/fsw/FCCode/MainControlLoop.hpp
+++ b/src/fsw/FCCode/MainControlLoop.hpp
@@ -10,6 +10,8 @@
 #include "PiksiControlTask.hpp"
 #include "ADCSBoxMonitor.hpp"
 #include "ADCSBoxController.hpp"
+#include "TimeEstimator.hpp"
+#include "OrbitEstimator.hpp"
 #include "AttitudeEstimator.hpp"
 #include "AttitudeController.hpp"
 #include "ADCSCommander.hpp"
@@ -40,6 +42,8 @@ class MainControlLoop : public ControlTask<void> {
 
     DebugTask debug_task;
 
+    TimeEstimator time_estimator;
+    OrbitEstimator orbit_estimator;
     AttitudeEstimator attitude_estimator;
 
     Devices::Gomspace::eps_hk_t hk;
@@ -102,6 +106,8 @@ class MainControlLoop : public ControlTask<void> {
     TRACKED_CONSTANT_SC(unsigned int, piksi_control_task_offset  ,   5500);
     TRACKED_CONSTANT_SC(unsigned int, adcs_monitor_offset        ,   7500);
     TRACKED_CONSTANT_SC(unsigned int, debug_task_offset          ,  35000);
+    TRACKED_CONSTANT_SC(unsigned int, time_estimator_offset      ,  35500 + test_offset); // TODO : Like wtf is this supposed to be...
+    TRACKED_CONSTANT_SC(unsigned int, orbit_estimator_offset     ,  35500 + test_offset); // TODO : ^^ same question
     TRACKED_CONSTANT_SC(unsigned int, attitude_estimator_offset  ,  35500 + test_offset);
     TRACKED_CONSTANT_SC(unsigned int, gomspace_controller_offset ,  56500 + test_offset);
     TRACKED_CONSTANT_SC(unsigned int, uplink_consumer_offset     ,  71500 + test_offset);

--- a/src/fsw/FCCode/OrbitEstimator.cpp
+++ b/src/fsw/FCCode/OrbitEstimator.cpp
@@ -1,0 +1,109 @@
+#include "OrbitEstimator.hpp"
+
+#include "constants.hpp"
+#include "piksi_mode_t.enum"
+
+#include <gnc/config.hpp>
+#include <gnc/constants.hpp>
+#include <gnc/environment.hpp>
+
+#include <lin/core.hpp>
+#include <lin/generators.hpp>
+#include <lin/math.hpp>
+
+// Estimator process noise
+TRACKED_CONSTANT_SC(double, Orbit_sqrtQ_r, 0.1);
+TRACKED_CONSTANT_SC(double, Orbit_sqrtQ_v, 0.1);
+static constexpr lin::Vectord<6> sqrtQ_diag {Orbit_sqrtQ_r, Orbit_sqrtQ_r,
+        Orbit_sqrtQ_r, Orbit_sqrtQ_v, Orbit_sqrtQ_v, Orbit_sqrtQ_v};
+static constexpr lin::Matrixd<6, 6> sqrtQ {lin::diag(sqrtQ_diag)};
+
+// Estimator sensor noise
+TRACKED_CONSTANT_SC(double, Orbit_sqrtR_r, 5.0);
+TRACKED_CONSTANT_SC(double, Orbit_sqrtR_v, 5.0);
+static constexpr lin::Vectord<6> sqrtR_diag {Orbit_sqrtR_r, Orbit_sqrtR_r,
+        Orbit_sqrtR_r, Orbit_sqrtR_v, Orbit_sqrtR_v, Orbit_sqrtR_v};
+static constexpr lin::Matrixd<6, 6> sqrtR {lin::diag(sqrtR_diag)};
+
+OrbitEstimator::OrbitEstimator(
+        StateFieldRegistry &registry, unsigned int offset)
+    : TimedControlTask<void>(registry, "orbit_estimator", offset),
+      piksi_state_fp(FIND_READABLE_FIELD(unsigned char, piksi.state)),
+      piksi_microdelta_fp(FIND_READABLE_FIELD(unsigned int, piksi.microdelta)),
+      piksi_pos_fp(FIND_READABLE_FIELD(lin::Vector3d, piksi.pos)),
+      piksi_vel_fp(FIND_READABLE_FIELD(lin::Vector3d, piksi.vel)),
+      time_valid_fp(FIND_READABLE_FIELD(bool, time.valid)),
+      time_s_fp(FIND_INTERNAL_FIELD(double, time.s)),
+      time_ns_fp(FIND_INTERNAL_FIELD(unsigned long long, time.ns)),
+      orbit_valid_f("orbit.valid", Serializer<bool>()),
+      orbit_pos_f("orbit.pos", Serializer<lin::Vector3d>(6771000, 6921000, 28)),
+      orbit_vel_f("orbit.vel", Serializer<lin::Vector3d>(7570, 7685, 19)),
+      orbit_reset_f("orbit.reset", Serializer<bool>())
+{
+    add_readable_field(orbit_valid_f);
+    add_readable_field(orbit_pos_f);
+    add_readable_field(orbit_vel_f);
+    add_writable_field(orbit_reset_f);
+
+    orbit_valid_f.set(false);
+    orbit_reset_f.set(false);
+    orbit_pos_f.set(lin::zeros<lin::Vector3d>());
+    orbit_vel_f.set(lin::zeros<lin::Vector3d>());
+}
+
+void OrbitEstimator::execute()
+{
+    if (!time_valid_fp->get() || orbit_reset_f.get())
+    {
+        orbit_valid_f.set(false);
+        orbit_reset_f.set(false);
+        return;
+    }
+
+    auto const piksi_mode = static_cast<piksi_mode_t>(piksi_state_fp->get());
+    auto const piksi_dns = static_cast<unsigned long long>(1000 * piksi_microdelta_fp->get());
+    auto const w_earth_ecef = [](double t) {
+        lin::Vector3d w_earth_ecef;
+        gnc::env::earth_angular_rate(t, w_earth_ecef);
+        return w_earth_ecef;
+    }(time_s_fp->get());
+
+    double _;
+    switch (piksi_mode)
+    {
+    // Received a valid position and velocity reading from Piksi
+    case piksi_mode_t::spp:
+    case piksi_mode_t::float_rtk:
+    case piksi_mode_t::fixed_rtk:
+        // Pass MINGPSTIME_NS until the timestampo is removed from the class
+        orb::OrbitEstimate measurement(orb::MINGPSTIME_NS, piksi_pos_fp->get(),
+                piksi_vel_fp->get(), sqrtR);
+        measurement.shortupdate(piksi_dns, w_earth_ecef, sqrtQ, _);
+
+        if (_estimate.valid())
+        {
+            _estimate.shortupdate(PAN::control_cycle_time_ns, w_earth_ecef,
+                    measurement.recef(), measurement.vecef(), sqrtQ, measurement.S(), _);
+        }
+        else
+        {
+            _estimate = measurement;
+        }
+        break;
+
+    // No valid reading from Piksi
+    default:
+        if (_estimate.valid())
+        {
+            _estimate.shortupdate(PAN::control_cycle_time_ns, w_earth_ecef, sqrtQ, _);
+        }
+        break;
+    }
+
+    orbit_valid_f.set(_estimate.valid());
+    if (orbit_valid_f.get())
+    {
+        orbit_pos_f.set(_estimate.recef());
+        orbit_vel_f.set(_estimate.vecef());
+    }
+}

--- a/src/fsw/FCCode/OrbitEstimator.hpp
+++ b/src/fsw/FCCode/OrbitEstimator.hpp
@@ -1,0 +1,65 @@
+#ifndef ORBIT_ESTIMATOR_HPP_
+#define ORBIT_ESTIMATOR_HPP_
+
+#include "TimedControlTask.hpp"
+
+#include <lin/core.hpp>
+
+#include <orb/OrbitEstimate.hpp>
+
+/** @author Kyle Krol
+ *
+ *  @brief Provides an estimate of this spacecraft's position and velocity given
+ *         a time estimate and information from the Piksi.
+ *
+ *  The time estimate must be valid for the orbit estimate to be considered
+ *  valid. Resetting the time estimate will cause the orbit estimate to be reset
+ *  as well.
+ *
+ *  The position and velocity of the spacecraft are provided in ECEF.
+ */
+class OrbitEstimator : public TimedControlTask<void>
+{
+  public:
+    OrbitEstimator() = delete;
+    OrbitEstimator(OrbitEstimator const &) = delete;
+    OrbitEstimator(OrbitEstimator &&) = delete;
+    OrbitEstimator &operator=(OrbitEstimator const &) = delete;
+    OrbitEstimator &operator=(OrbitEstimator &&) = delete;
+
+    ~OrbitEstimator() = default;
+
+    OrbitEstimator(StateFieldRegistry &registry, unsigned int offset);
+
+    void execute() override;
+
+  protected:
+    /* Take position, velocity, relative position, time, time delay, and current
+     * static readings in from Piksi.
+     */
+    ReadableStateField<unsigned char> const *const piksi_state_fp;
+    ReadableStateField<unsigned int> const *const piksi_microdelta_fp;
+    ReadableStateField<lin::Vector3d> const *const piksi_pos_fp;
+    ReadableStateField<lin::Vector3d> const *const piksi_vel_fp;
+
+    /* Take the current time estimate from the time estimator.
+     */
+    ReadableStateField<bool> const *const time_valid_fp;
+    InternalStateField<double> const *const time_s_fp;
+    InternalStateField<unsigned long long> const *const time_ns_fp;
+
+    /* Outputs for current position and velocity estimates of this satellite.
+     */
+    ReadableStateField<bool> orbit_valid_f;
+    ReadableStateField<lin::Vector3d> orbit_pos_f;
+    ReadableStateField<lin::Vector3d> orbit_vel_f;
+
+    /* Command to forcibly reset the orbit estimate.
+     */
+    WritableStateField<bool> orbit_reset_f;
+
+  private:
+    orb::OrbitEstimate _estimate;
+};
+
+#endif

--- a/src/fsw/FCCode/TimeEstimator.cpp
+++ b/src/fsw/FCCode/TimeEstimator.cpp
@@ -1,0 +1,64 @@
+#include "TimeEstimator.hpp"
+
+#include "constants.hpp"
+#include "piksi_mode_t.enum"
+
+#include <gnc/config.hpp>
+#include <gnc/constants.hpp>
+
+TimeEstimator::TimeEstimator(StateFieldRegistry &registry, unsigned int offset)
+    : TimedControlTask<void>(registry, "time_estimator", offset),
+      piksi_state_fp(FIND_READABLE_FIELD(usnigned char, piksi.state)),
+      piksi_microdelta_fp(FIND_READABLE_FIELD(unsigned int, piksi.microdelta)),
+      piksi_time_fp(FIND_READABLE_FIELD(gps_time_t, piksi.time)),
+      time_valid_f("time.valid", Serializer<bool>()),
+      time_s_f("time.s"),
+      time_ns_f("time.ns"),
+      time_gps_f("time.gps", Serializer<gps_time_t>()),
+      time_reset_f("time.reset", Serializer<bool>())
+{
+    add_readable_field(time_valid_f);
+    add_internal_field(time_s_f);
+    add_internal_field(time_ns_f);
+    add_readable_field(time_gps_f);
+    add_writable_field(time_reset_f);
+
+    time_valid_f.set(false);
+    time_reset_f.set(false);
+}
+
+void TimeEstimator::execute()
+{
+    if (time_reset_f.get())
+    {
+        time_valid_f.set(false);
+        time_reset_f.set(false);
+        return;
+    }
+
+    auto const piksi_mode = static_cast<piksi_mode_t>(piksi_state_fp->get());
+    auto const piksi_dns = static_cast<unsigned long long>(1000 * piksi_microdelta_fp->get());
+    auto const gps_epoch_ns = static_cast<unsigned long long>(gps_time_t(
+            gnc::constant::init_gps_week_number, gnc::constant::init_gps_time_of_week,
+            gnc::constant::init_gps_nanoseconds));
+
+    switch (piksi_mode)
+    {
+    // Received a valid time reading from Piksi
+    case piksi_mode_t::spp:
+    case piksi_mode_t::float_rtk:
+    case piksi_mode_t::fixed_rtk:
+        time_gps_f.set(piksi_time_fp->get() + piksi_dns);
+        time_valid_f.set(true);
+        break;
+
+    // No valid time reading from Piksi
+    default:
+        time_gps_f.set(time_gps_f.get() + PAN::control_cycle_time_ns);
+        break;
+    }
+
+    // Update the other fields (means nothing it time is invalid anyway)
+    time_ns_f.set(static_cast<unsigned long long>(time_gps_f.get()) - gps_epoch_ns);
+    time_s_f.set(static_cast<double>(time_ns_f.get()) * 1.0e-9);
+}

--- a/src/fsw/FCCode/TimeEstimator.hpp
+++ b/src/fsw/FCCode/TimeEstimator.hpp
@@ -1,0 +1,57 @@
+#ifndef TIME_ESTIMATOR_HPP_
+#define TIME_ESTIMATOR_HPP_
+
+#include "TimedControlTask.hpp"
+
+#include <common/GPSTime.hpp>
+
+/** @author Kyle Krol
+ *
+ *  @brief Provides an estimate of the current time given information from the
+ *         Piksi.
+ *
+ *  The time estimate is considered invalid until the Piksi provides at least a
+ *  single GPS time reading. From then on, the time estimate will always remain
+ *  valid and update itself either from Piksi or based on the expected length of
+ *  a control cycle.
+ *
+ *  Note that the time estimate isn't guranteed to be monotonically increasing
+ *  and, as such, sequential time estimates shouldn't be used to calculate
+ *  timestep sizes; use the control cycle length constants instead.
+ */
+class TimeEstimator : public TimedControlTask<void>
+{
+  public:
+    TimeEstimator() = delete;
+    TimeEstimator(TimeEstimator const &) = delete;
+    TimeEstimator(TimeEstimator &&) = delete;
+    TimeEstimator &operator=(TimeEstimator const &) = delete;
+    TimeEstimator &operator=(TimeEstimator &&) = delete;
+
+    ~TimeEstimator() = default;
+
+    TimeEstimator(StateFieldRegistry &registry, unsigned int offset);
+
+    void execute() override;
+
+  protected:
+    /* Take position, velocity, relative position, time, time delay, and current
+     * static readings in from Piksi.
+     */
+    ReadableStateField<unsigned char> const *const piksi_state_fp;
+    ReadableStateField<unsigned int> const *const piksi_microdelta_fp;
+    ReadableStateField<gps_time_t> const *const piksi_time_fp;
+
+    /* Outputs the current time estimate.
+     */
+    ReadableStateField<bool> time_valid_f;
+    ReadableStateField<gps_time_t> time_gps_f;
+    InternalStateField<unsigned long long> time_ns_f;
+    InternalStateField<double> time_s_f;
+
+    /* Command to forcibly reset the time estimate.
+     */
+    WritableStateField<bool> time_reset_f;
+};
+
+#endif

--- a/src/fsw/FCCode/constants.hpp
+++ b/src/fsw/FCCode/constants.hpp
@@ -8,23 +8,25 @@ namespace PAN {
     // control_cycle_time is the value actually used for timing. The
     // other constants are just informational.
     #ifdef FLIGHT
-        TRACKED_CONSTANT_C(unsigned int, control_cycle_time_ms, 120);
-        TRACKED_CONSTANT_C(unsigned int, control_cycle_time_us, 120000);
-        TRACKED_CONSTANT_C(unsigned int, control_cycle_time, 120000);
+        TRACKED_CONSTANT_SC(unsigned int, control_cycle_time_ms, 120);
+        TRACKED_CONSTANT_SC(unsigned int, control_cycle_time_us, control_cycle_time_ms * 1000);
+        TRACKED_CONSTANT_SC(unsigned int, control_cycle_time_ns, control_cycle_time_us * 1000);
+        TRACKED_CONSTANT_SC(unsigned int, control_cycle_time, control_cycle_time_us);
     #else
-        TRACKED_CONSTANT_C(unsigned int, control_cycle_time_ms, 170);
-        TRACKED_CONSTANT_C(unsigned int, control_cycle_time_us, 170000);
+        TRACKED_CONSTANT_SC(unsigned int, control_cycle_time_ms, 170);
+        TRACKED_CONSTANT_SC(unsigned int, control_cycle_time_us, control_cycle_time_ms * 1000);
+        TRACKED_CONSTANT_SC(unsigned int, control_cycle_time_ns, control_cycle_time_us * 1000);
         #ifdef DESKTOP
-            TRACKED_CONSTANT_C(unsigned int, control_cycle_time, 170000000);
+            TRACKED_CONSTANT_SC(unsigned int, control_cycle_time, 170000000);
         #else
-            TRACKED_CONSTANT_C(unsigned int, control_cycle_time, 170000);
+            TRACKED_CONSTANT_SC(unsigned int, control_cycle_time_us, 170000);
         #endif
     #endif
 
     #ifdef SPEEDUP
-        TRACKED_CONSTANT_C(unsigned int, one_day_ccno, 10 * 1000 / control_cycle_time_ms);
+        TRACKED_CONSTANT_SC(unsigned int, one_day_ccno, 10 * 1000 / control_cycle_time_ms);
     #else
-        TRACKED_CONSTANT_C(unsigned int, one_day_ccno, 24 * 60 * 60 * 1000 / control_cycle_time_ms);
+        TRACKED_CONSTANT_SC(unsigned int, one_day_ccno, 24 * 60 * 60 * 1000 / control_cycle_time_ms);
     #endif
 }
 

--- a/test/test_fsw_time_estimator/test_fsw_time_estimator.cpp
+++ b/test/test_fsw_time_estimator/test_fsw_time_estimator.cpp
@@ -1,0 +1,28 @@
+#include "../StateFieldRegistryMock.hpp"
+
+
+
+int test_control_task()
+{
+        UNITY_BEGIN();
+        RUN_TEST(test_task_initialization);
+        return UNITY_END();
+}
+
+#ifdef DESKTOP
+int main()
+{
+        return test_control_task();
+}
+#else
+#include <Arduino.h>
+void setup()
+{
+        delay(2000);
+        Serial.begin(9600);
+        test_control_task();
+}
+
+void loop() {}
+#endif
+


### PR DESCRIPTION
Relates to #349
Closes #655
Closes #607

### Summary of changes

- Added the `TimeEstimator` control task which takes in information from Piksi and provides the rest of flight software with our current best guess of absolute time. As noted in the comments, this should really only be used for GNC models and flight software shouldn't use sequential estimates to calculate timestep lengths.
- Added the `OrbitEstimator` control task which takes in the time estimate and Piksi information to provide an estimate of this satellite's position and velocity.

See #349 for updates on the overall number and structure of the orbit control tasks -- still a WIP.

### Testing

WIP

### Constants

Describe any important diffs to the `constants` file in the root level of the repository. Ensure that any constants you added to the code successfully made it into the `constants` file. If not, wrap the missing constants with `TRACKED_CONSTANT` macros and fix `constants_reporter.py` if necessary.

### Telemetry

Describe any important diffs to the `telemetry` file in the root level of the repository. Ensure that any telemetry you added to the code successfully made it into the `telemetry` file.

Also, take the opportunity to add the telemetry into the appropriate flows in src/flow_data.csv.
