### PR TITLE
QOL (Quality of Life) upgrades for dual HITL drive

### DIFF
--- a/ptest/cases/dual_psim.py
+++ b/ptest/cases/dual_psim.py
@@ -47,6 +47,7 @@ class DualPsim(MissionCase):
         
         fc_states = ["pan.deployment.elapsed",
         "pan.state",
+        "radio.state",
         "pan.cycle_no",
         "pan.bootcount",
         "adcs.state",

--- a/ptest/cases/psim_debug.py
+++ b/ptest/cases/psim_debug.py
@@ -54,6 +54,7 @@ class PsimDebug(SingleSatOnlyCase):
 
         self.rs("pan.deployment.elapsed")
         self.rs("pan.state")
+        self.rs("radio.state")
         self.rs("pan.cycle_no")
         self.rs("pan.bootcount")
         self.rs("adcs.state")

--- a/ptest/cases/reboot_utility.py
+++ b/ptest/cases/reboot_utility.py
@@ -1,10 +1,10 @@
-# Case that reboots the satellite. Utility purposes only.
+# Case that reboots the satellite (by setting the reset flag). Utility purposes only.
 from .base import SingleSatOnlyCase
 from .utils import Enums, TestCaseFailure
 import os
 
 class Reboot(SingleSatOnlyCase):
     def run_case_singlesat(self):
-        self.ws("gomspace.gs_reboot_cmd", True)
+        self.ws("gomspace.gs_reset_cmd", True)
         self.cycle()
         self.finish()


### PR DESCRIPTION
# QOL Upgrades

Makes things nicer for Dual HITL testing, and live plotting of things.

### Summary of changes
- Added radio.state to psim debug
- Changed reboot to use reset_cmd
