### PR TITLE
Automatic ElasticSearch Index in MCT from config file argument

### DIFF
--- a/MCT/README.md
+++ b/MCT/README.md
@@ -28,6 +28,12 @@ This Mission control API uses the visual elements of the openMCT data visualizat
 
 The openMCT web server is run using the **```npm start```** command in terminal after navigating to the /MCT directory and installing the node.js modules with **```npm install```**.
 
+Running **```npm start```** default to using the ci.json configuration file. you can specify the configuration file that you want MCT to use by appending an argument containing the path relative to FlightSoftware root directory.
+
+For example:
+
+**```npm start ptest/configs/dual_usb.json```** would start MCT using the configuration file dual_usb.json
+
 In Open MCT everything is represented as a Domain Object, this includes sources of telemetry, telemetry points, and views for visualizing telemetry. Domain Objects are accessible from the object tree shown on the left side of the openMCT display.
 
 ## Setting up a new Subsystem or Domain Object

--- a/MCT/README.md
+++ b/MCT/README.md
@@ -32,7 +32,7 @@ Running **```npm start```** default to using the ci.json configuration file. you
 
 For example:
 
-**```npm start ptest/configs/dual_usb.json```** would start MCT using the configuration file dual_usb.json
+**```npm start ptest/configs/dual_usb.json```** would start MCT using the configuration file dual_usb.json. Make sure the config file has at least 1 device or 1 radio and that it is a valid ptest config file.
 
 In Open MCT everything is represented as a Domain Object, this includes sources of telemetry, telemetry points, and views for visualizing telemetry. Domain Objects are accessible from the object tree shown on the left side of the openMCT display.
 

--- a/MCT/server-files/server.js
+++ b/MCT/server-files/server.js
@@ -1,6 +1,10 @@
 /**
  * Basic implementation of a history and realtime server for MCT.
  */
+
+//get arguments
+var myArgs = process.argv.slice(2);
+
 var Telemetry= require('./telemetry');
 var RealtimeServer = require('./boilerplate-mct-servers/realtime-server');
 var HistoryServer = require('./boilerplate-mct-servers/history-server');
@@ -16,7 +20,12 @@ var credentials = {key: privateKey, cert: certificate};
 var app = express()
 expressWs(app);
 
-var spacecraft = new Telemetry();
+//sets default config file to ci.json
+if(myArgs[0] == undefined){
+  myArgs[0] = "ptest/configs/ci.json"
+}
+
+var spacecraft = new Telemetry(myArgs[0]);
 var realtimeServer = new RealtimeServer(spacecraft);
 var historyServer = new HistoryServer(spacecraft);
 

--- a/MCT/server-files/telemetry.js
+++ b/MCT/server-files/telemetry.js
@@ -21,53 +21,53 @@ var searchURl = 'http://localhost:5000/search-es';
  */
 function Telemetry(configuration) {
 
-    var FlightSoftware = path.resolve(__dirname, '../..')
-    var config_file = FlightSoftware + "/" + configuration
-    var config_json = require(config_file);
-    /**
-    * The index of the Elastic Search database
-    */
-    if(config_json.devices.length>0){
-      this.searchIndex = 'statefield_report_' + config_json.devices[0].imei
-    }
-    else if(config_json.radios.length>0){
-      this.searchIndex = 'statefield_report_' + config_json.radios[0].imei
-    }
-    else{
-      this.searchIndex = 'statefield_report_'
-    }
-    //This state function takes in initial values from the state-variables.js file
-    this.initialState = variables;
+  var FlightSoftware = path.resolve(__dirname, '../..')
+  var config_file = FlightSoftware + "/" + configuration
+  var config_json = require(config_file);
+  /**
+  * The index of the Elastic Search database
+  */
+  if (config_json.devices.length > 0) {
+    this.searchIndex = 'statefield_report_' + config_json.devices[0].imei
+  }
+  else if (config_json.radios.length > 0) {
+    this.searchIndex = 'statefield_report_' + config_json.radios[0].imei
+  }
+  else {
+    throw "Malformed: There are no devices or radios in this config file"
+  }
+  //This state function takes in initial values from the state-variables.js file
+  this.initialState = variables;
 
-    //all of the current values for the telemetry
-    this.state = {};
+  //all of the current values for the telemetry
+  this.state = {};
 
-    //creates an entry in state for every variable in './state-variables'
-    Object.entries(this.initialState).forEach(function ([statesSubsystem,v]) {
-      Object.entries(v).forEach(function ([k,v]) {
-        let key = statesSubsystem + '.' + k;
-        this.state[key] = v;
-      }, this);
+  //creates an entry in state for every variable in './state-variables'
+  Object.entries(this.initialState).forEach(function ([statesSubsystem, v]) {
+    Object.entries(v).forEach(function ([k, v]) {
+      let key = statesSubsystem + '.' + k;
+      this.state[key] = v;
     }, this);
+  }, this);
 
-    //all of the historical telemetry data
-    this.history = {};
+  //all of the historical telemetry data
+  this.history = {};
 
-    //the listeners for the real time telemetry
-    this.listeners = [];
+  //the listeners for the real time telemetry
+  this.listeners = [];
 
-    //adds all the initial values to history
-    Object.entries(this.state).forEach(function ([k,v]) {
-      this.history[k] = [];
-    }, this);
+  //adds all the initial values to history
+  Object.entries(this.state).forEach(function ([k, v]) {
+    this.history[k] = [];
+  }, this);
 
-    //updates the states, generates the realtime listers/notifications and historical telemetry ever 1 second.
-    setInterval(function () {
-        this.updateState();
-        this.generateTelemetry();
-    }.bind(this), 1000);
+  //updates the states, generates the realtime listers/notifications and historical telemetry ever 1 second.
+  setInterval(function () {
+    this.updateState();
+    this.generateTelemetry();
+  }.bind(this), 1000);
 
-    console.log("Now reading spacecraft telemetry")
+  console.log("Now reading spacecraft telemetry")
 
 };
 
@@ -84,17 +84,17 @@ Telemetry.prototype.updateState = async function () {
   Object.keys(this.state).forEach(async function (id) {
 
     //if the value for the key of the state entry is an object
-    if(typeof(this.state[id]) == 'object'){
-      
-      Object.keys(this.state[id]).forEach(async function (subId){
+    if (typeof (this.state[id]) == 'object') {
+
+      Object.keys(this.state[id]).forEach(async function (subId) {
         //send a request to Elastic Search for the field
         let res = await this.getValue(searchURl, this.searchIndex, id + '.' + subId);
         (this.state[id])[subId] = res;//update state
-      },this)
+      }, this)
 
     }
     //if the value for the key of the state entry is a primitive
-    else{
+    else {
       //send a request to Elastic Search for the field
       let res = await this.getValue(searchURl, this.searchIndex, id);
       this.state[id] = res;//update state
@@ -111,21 +111,21 @@ Telemetry.prototype.updateState = async function () {
  * @param {*} i  the index of the Elastic Search database
  * @param {*} f the field that's value is being requested
  */
-Telemetry.prototype.getValue = async function(myUrl, i, f){
-  
-  //properties of the search
-  var propertiesObject = { index: i, field:f };
+Telemetry.prototype.getValue = async function (myUrl, i, f) {
 
-  let p = new Promise(function(resolve, reject){
+  //properties of the search
+  var propertiesObject = { index: i, field: f };
+
+  let p = new Promise(function (resolve, reject) {
 
     //requests URL based on properties
-    request({url: myUrl, qs:propertiesObject}, function(err, response, body) {
-      if(!err && response.statusCode == 200) { resolve(body);}
-      else{ reject(err); }
+    request({ url: myUrl, qs: propertiesObject }, function (err, response, body) {
+      if (!err && response.statusCode == 200) { resolve(body); }
+      else { reject(err); }
     });
   });
   return await p;
-  }
+}
 
 
 
@@ -140,37 +140,37 @@ Telemetry.prototype.getValue = async function(myUrl, i, f){
  *   for the state value directly
  */
 Telemetry.prototype.generateTelemetry = function () {
-    var timestamp = Date.now(), sent = 0;
-    //make two cases one that updates objects and one that directly updates field
-    
-    Object.keys(this.state).forEach(function (id) {
+  var timestamp = Date.now(), sent = 0;
+  //make two cases one that updates objects and one that directly updates field
 
-      //if the value for the key of the state entry is an object
-      if(typeof(this.state[id]) == 'object'){
+  Object.keys(this.state).forEach(function (id) {
 
-        //generate telemetry point oject
-        var telempoint = { timestamp: timestamp, id: id};
-        for (const output in this.state[id]){
-          telempoint[output] = this.state[id][output];
-        }
+    //if the value for the key of the state entry is an object
+    if (typeof (this.state[id]) == 'object') {
 
-        //notify the realtime server and push the datapoint to the history server
-        this.notify(telempoint);
-        this.history[id].push(telempoint);
-
-      }
-      //if the value for the key of the state entry is a primitive
-      else{
-
-        //generate telemetry point primitve state
-        var telempoint = { timestamp: timestamp, value: this.state[id], id: id};
-
-        //notify the realtime server and push the datapoint to the history server
-        this.notify(telempoint);
-        this.history[id].push(telempoint);
+      //generate telemetry point oject
+      var telempoint = { timestamp: timestamp, id: id };
+      for (const output in this.state[id]) {
+        telempoint[output] = this.state[id][output];
       }
 
-    }, this);
+      //notify the realtime server and push the datapoint to the history server
+      this.notify(telempoint);
+      this.history[id].push(telempoint);
+
+    }
+    //if the value for the key of the state entry is a primitive
+    else {
+
+      //generate telemetry point primitve state
+      var telempoint = { timestamp: timestamp, value: this.state[id], id: id };
+
+      //notify the realtime server and push the datapoint to the history server
+      this.notify(telempoint);
+      this.history[id].push(telempoint);
+    }
+
+  }, this);
 
 };
 
@@ -180,9 +180,9 @@ Telemetry.prototype.generateTelemetry = function () {
  * @param {*} point The telelmetry point to notify an update to to the realtime server for
  */
 Telemetry.prototype.notify = function (point) {
-    this.listeners.forEach(function (l) {
-        l(point);
-    });
+  this.listeners.forEach(function (l) {
+    l(point);
+  });
 };
 
 /**
@@ -191,16 +191,16 @@ Telemetry.prototype.notify = function (point) {
  * @param {*} listener The lister being added
  */
 Telemetry.prototype.listen = function (listener) {
-    //adds the listener
-    this.listeners.push(listener);
-    return function () {
-        this.listeners = this.listeners.filter(function (l) {
-            return l !== listener;
-        });
-    }.bind(this);
+  //adds the listener
+  this.listeners.push(listener);
+  return function () {
+    this.listeners = this.listeners.filter(function (l) {
+      return l !== listener;
+    });
+  }.bind(this);
 };
 
 //exports the telemetry function for use in './server.js'
 module.exports = function (config) {
-    return new Telemetry(config)
+  return new Telemetry(config)
 };


### PR DESCRIPTION
# Configuration for MCT ES Indexes (Part One: Single Sat)

Fixes #668 

### Summary of changes
- Added the ability to send a configuration file path to the telemetry.js file from the main npm start script like this:
`npm start ptest/configs/dual_usb.json`
- path must be relative to Flight Software (such as ptest/configs/dual_usb.json)
- it can be a file with just usbs or a file with just radios it does not matter
- if it has neither usb or radio in given file, it defaults to the same index as ci.json's index
- default path (if no path argument is entered is ptest/configs/ci.json)

Note: at the moment this is only single sat configuration (because all that is in master is single mct), however looking forward this same config variable passed in can be used to indicate to mct whether you want it to run with 2 satellites or 1 satellite (depending on the number of radios or usbs in the config file) -> this will be implemented into the dual_mct_isolated branch or a seperate branch after that is merged in

### Testing

Tested with many different configuration files and imei numbers to see if it automatically checks the correct indexes and it does. This was verified by viewing the data in OpenMCT

### Constants

N/A

### Telemetry

N/A

### Documentation Evidence

- Added information to the MCT README to explain the usage of the configuration argument
- Added a few relevent in-line comments