### PR TITLE
Changes stray tabs to spaces

### DIFF
--- a/src/fsw/FCCode/Estimators/OrbitEstimator.cpp
+++ b/src/fsw/FCCode/Estimators/OrbitEstimator.cpp
@@ -63,9 +63,9 @@ void OrbitEstimator::execute()
         orbit_valid_f.set(false);
         orbit_reset_cmd_f.set(false);
 
-	  _estimate = orb::OrbitEstimate();
+        _estimate = orb::OrbitEstimate();
 
-	  return;
+        return;
     }
 
     auto const piksi_mode = static_cast<piksi_mode_t>(piksi_state_fp->get());


### PR DESCRIPTION
Per the title. This was as accident from a hotfix just prior to merging the orbit estimator PR.