### PR TITLE
updated requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ colorama==0.4.1
 contextlib2==0.5.5
 cycler==0.10.0
 docker==4.1.0
-elasticsearch==7.1.0
+elasticsearch
 entrypoints==0.3
 flake8==3.7.9
 flasgger==0.9.3
@@ -36,12 +36,12 @@ lazy-object-proxy==1.4.2
 lxml==4.6.2
 MarkupSafe==1.1.1
 marshmallow==2.20.5
-matplotlib==3.1.1
+matplotlib
 mccabe==0.6.1
 mistune==0.8.4
 more-itertools==7.2.0
 mplcursors==0.3
-numpy==1.17.2
+numpy
 oauth2client==4.1.3
 packaging==19.2
 platformio==5.0.3
@@ -66,7 +66,6 @@ schema==0.7.1
 semantic-version==2.8.2
 six==1.12.0
 tabulate==0.8.5
-typed-ast<=1.4.0
 uritemplate==3.0.1
 urllib3==1.25.7
 virtualenv==16.6.0


### PR DESCRIPTION
# Updated Requirements
Fixes: requirements versioning too restrictive. elasticsearch, matplotlib, numpy should be safe to upgrade. 

### Summary of changes
- removed version number for elasticsearch, matplotlib, numpy
