### PR TITLE
Relative Orbit Estimator

### DIFF
--- a/src/fsw/FCCode/Estimators/OrbitEstimator.cpp
+++ b/src/fsw/FCCode/Estimators/OrbitEstimator.cpp
@@ -5,7 +5,6 @@
 
 #include <gnc/config.hpp>
 #include <gnc/constants.hpp>
-#include <gnc/environment.hpp>
 
 #include <lin/core.hpp>
 #include <lin/generators.hpp>
@@ -32,8 +31,8 @@ OrbitEstimator::OrbitEstimator(StateFieldRegistry &registry)
       piksi_pos_fp(FIND_READABLE_FIELD(lin::Vector3d, piksi.pos)),
       piksi_vel_fp(FIND_READABLE_FIELD(lin::Vector3d, piksi.vel)),
       time_valid_fp(FIND_READABLE_FIELD(bool, time.valid)),
-      time_s_fp(FIND_INTERNAL_FIELD(double, time.s)),
       time_ns_fp(FIND_INTERNAL_FIELD(unsigned long long, time.ns)),
+      time_earth_w_fp(FIND_INTERNAL_FIELD(lin::Vector3d, time.earth.w)),
       orbit_valid_f("orbit.valid", Serializer<bool>()),
       orbit_pos_f("orbit.pos", Serializer<lin::Vector3d>(6771000, 6921000, 28)),
       orbit_pos_sigma_f("orbit.pos_sigma", Serializer<lin::Vector3d>(0, 100, 12)),
@@ -70,11 +69,7 @@ void OrbitEstimator::execute()
 
     auto const piksi_mode = static_cast<piksi_mode_t>(piksi_state_fp->get());
     auto const piksi_dns = static_cast<unsigned long long>(1000 * piksi_microdelta_fp->get());
-    auto const w_earth_ecef = [](double t) {
-        lin::Vector3d w_earth_ecef;
-        gnc::env::earth_angular_rate(t, w_earth_ecef);
-        return w_earth_ecef;
-    }(time_s_fp->get());
+    auto const w_earth_ecef = time_earth_w_fp->get();
 
     double _;
     switch (piksi_mode)

--- a/src/fsw/FCCode/Estimators/OrbitEstimator.hpp
+++ b/src/fsw/FCCode/Estimators/OrbitEstimator.hpp
@@ -35,8 +35,8 @@ class OrbitEstimator : public ControlTask<void>
     void execute() override;
 
   protected:
-    /* Take position, velocity, relative position, time, time delay, and current
-     * static readings in from Piksi.
+    /* Take position, velocity, time, time delay, and current state readings in
+     * from Piksi.
      */
     ReadableStateField<unsigned char> const *const piksi_state_fp;
     ReadableStateField<unsigned int> const *const piksi_microdelta_fp;
@@ -46,8 +46,8 @@ class OrbitEstimator : public ControlTask<void>
     /* Take the current time estimate from the time estimator.
      */
     ReadableStateField<bool> const *const time_valid_fp;
-    InternalStateField<double> const *const time_s_fp;
     InternalStateField<unsigned long long> const *const time_ns_fp;
+    InternalStateField<lin::Vector3d> const *const time_earth_w_fp;
 
     /* Outputs for current position and velocity estimates of this satellite.
      */

--- a/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
+++ b/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
@@ -251,8 +251,8 @@ void RelativeOrbitEstimator::execute()
 
                         lin::Vector3d baseline_dv =
                                 1.0e9 * (piksi_baseline_pos - _previous_baseline_pos) / double(_previous_baseline_ns);
-                        
-                        DD("Initializeing relative orbit estimate with:");
+
+                        DD("Initializing the relative orbit estimate with:");
                         DD("\trel_pos = %f,%f,%f", -piksi_baseline_pos(0), -piksi_baseline_pos(1), -piksi_baseline_pos(2));
                         DD("\trel_vel = %f,%f,%f", -baseline_dv(0), -baseline_dv(1), -baseline_dv(2));
 

--- a/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
+++ b/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
@@ -165,8 +165,8 @@ void RelativeOrbitEstimator::execute()
 
             if (ns < 2u * PAN::control_cycle_time_ns)
             {
-                auto const signed_ns =  static_cast<unsigned int>(ns) -
-                        static_cast<unsigned int>(PAN::control_cycle_time_ns);
+                auto const signed_ns =  static_cast<signed int>(ns) -
+                        static_cast<signed int>(PAN::control_cycle_time_ns);
 
                 double _;
                 _orbit = orb::Orbit(orb::MINGPSTIME_NS, _uplink_r, _uplink_v);

--- a/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
+++ b/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
@@ -1,0 +1,291 @@
+#include "RelativeOrbitEstimator.hpp"
+
+#include <fsw/FCCode/constants.hpp>
+#include <fsw/FCCode/Estimators/rel_orbit_state_t.enum>
+#include <fsw/FCCode/piksi_mode_t.enum>
+
+#include <gnc/config.hpp>
+#include <gnc/environment.hpp>
+
+#include <lin/core.hpp>
+#include <lin/generators.hpp>
+#include <lin/math.hpp>
+#include <lin/references.hpp>
+
+// Estimator process noise
+TRACKED_CONSTANT_SC(double, RelOrbit_sqrtQ_r, 1.0e-8);
+TRACKED_CONSTANT_SC(double, RelOrbit_sqrtQ_v, 1.0e-2);
+static constexpr lin::Vectord<6> sqrtQ_diag {RelOrbit_sqrtQ_r, RelOrbit_sqrtQ_r,
+        RelOrbit_sqrtQ_r, RelOrbit_sqrtQ_v, RelOrbit_sqrtQ_v, RelOrbit_sqrtQ_v};
+static constexpr lin::Matrixd<6, 6> sqrtQ = lin::diag(sqrtQ_diag);
+
+// Estimator sensor noise
+TRACKED_CONSTANT_SC(double, RelOrbit_sqrtR_r, 1.0e-1);
+static constexpr lin::Vector3d sqrtR_diag =
+        RelOrbit_sqrtR_r * lin::ones<lin::Vector3d>();
+static constexpr lin::Matrix3x3d sqrtR = lin::diag(sqrtR_diag);
+
+static inline auto get_gps_zero()
+{
+    return gps_time_t(0, 0, 0);
+}
+
+static inline constexpr auto cast_state(rel_orbit_state_t state)
+{
+    return static_cast<unsigned char>(state);
+}
+
+static inline constexpr auto cast_state(unsigned char state)
+{
+    return static_cast<rel_orbit_state_t>(state);
+}
+
+RelativeOrbitEstimator::RelativeOrbitEstimator(StateFieldRegistry &registry)
+    : ControlTask<void>(registry),
+      piksi_state_fp(FIND_READABLE_FIELD(unsigned char, piksi.state)),
+      piksi_microdelta_fp(FIND_READABLE_FIELD(unsigned int, piksi.microdelta)),
+      piksi_pos_fp(FIND_READABLE_FIELD(lin::Vector3d, piksi.pos)),
+      piksi_vel_fp(FIND_READABLE_FIELD(lin::Vector3d, piksi.vel)),
+      piksi_baseline_pos_fp(FIND_READABLE_FIELD(lin::Vector3d, piksi.baseline_pos)),
+      time_valid_fp(FIND_READABLE_FIELD(bool, time.valid)),
+      time_gps_fp(FIND_READABLE_FIELD(gps_time_t, time.gps)),
+      time_earth_w_fp(FIND_INTERNAL_FIELD(lin::Vector3d, time.earth.w)),
+      orbit_valid_fp(FIND_READABLE_FIELD(bool, orbit.valid)),
+      orbit_pos_fp(FIND_READABLE_FIELD(lin::Vector3d, orbit.pos)),
+      orbit_vel_fp(FIND_READABLE_FIELD(lin::Vector3d, orbit.vel)),
+      rel_orbit_state_f("rel_orbit.state", Serializer<unsigned char>(2)),
+      rel_orbit_pos_f("rel_orbit.pos", Serializer<lin::Vector3d>(6771000, 6921000, 28)),
+      rel_orbit_vel_f("rel_orbit.vel", Serializer<lin::Vector3d>(7570, 7685, 19)),
+      rel_orbit_rel_pos_f("rel_orbit.rel_pos", Serializer<lin::Vector3d>(0,2000,22)),
+      rel_orbit_rel_pos_sigma_f("rel_orbit.rel_pos_sigma", Serializer<lin::Vector3d>(0, 10, 12)),
+      rel_orbit_rel_vel_f("rel_orbit.rel_vel", Serializer<lin::Vector3d>(0,11,14)),
+      rel_orbit_rel_vel_sigma_f("rel_orbit.rel_vel_sigma", Serializer<lin::Vector3d>(0, 1, 12)),
+      rel_orbit_reset_cmd_f("rel_orbit.reset_cmd", Serializer<bool>()),
+      rel_orbit_uplink_time_f("rel_orbit.uplink.time", Serializer<gps_time_t>()),
+      rel_orbit_uplink_pos_f("rel_orbit.uplink.pos", Serializer<lin::Vector3d>(6771000, 6921000, 28)),
+      rel_orbit_uplink_vel_f("rel_orbit.uplink.vel", Serializer<lin::Vector3d>(7570, 7685, 19)),
+      _uplink_time(get_gps_zero()),
+      _have_previous_baseline(false)
+{
+    add_readable_field(rel_orbit_state_f);
+    add_readable_field(rel_orbit_pos_f);
+    add_readable_field(rel_orbit_vel_f);
+    add_readable_field(rel_orbit_rel_pos_f);
+    add_readable_field(rel_orbit_rel_pos_sigma_f);
+    add_readable_field(rel_orbit_rel_vel_f);
+    add_readable_field(rel_orbit_rel_vel_sigma_f);
+    add_writable_field(rel_orbit_uplink_time_f);
+    add_writable_field(rel_orbit_uplink_time_f);
+    add_writable_field(rel_orbit_uplink_pos_f);
+    add_writable_field(rel_orbit_uplink_vel_f);
+
+    rel_orbit_state_f.set(cast_state(rel_orbit_state_t::invalid));
+    rel_orbit_pos_f.set(lin::zeros<lin::Vector3d>());
+    rel_orbit_vel_f.set(lin::zeros<lin::Vector3d>());
+    rel_orbit_rel_pos_f.set(lin::zeros<lin::Vector3d>());
+    rel_orbit_rel_pos_sigma_f.set(lin::zeros<lin::Vector3d>());
+    rel_orbit_rel_vel_f.set(lin::zeros<lin::Vector3d>());
+    rel_orbit_rel_vel_sigma_f.set(lin::zeros<lin::Vector3d>());
+    rel_orbit_reset_cmd_f.set(false);
+    rel_orbit_uplink_time_f.set(get_gps_zero());
+    rel_orbit_uplink_pos_f.set(lin::zeros<lin::Vector3d>());
+    rel_orbit_uplink_vel_f.set(lin::zeros<lin::Vector3d>());
+}
+
+void RelativeOrbitEstimator::execute()
+{
+    {
+        auto const should_reset =
+            !time_valid_fp->get() || !orbit_valid_fp->get() || rel_orbit_reset_cmd_f.get();
+
+        if (should_reset)
+        {
+            rel_orbit_state_f.set(cast_state(rel_orbit_state_t::invalid));
+            rel_orbit_reset_cmd_f.set(false);
+
+            _relative_orbit = gnc::RelativeOrbitEstimate();
+            _orbit = orb::Orbit();
+
+            return;
+        }
+    }
+
+    auto const piksi_mode = static_cast<piksi_mode_t>(piksi_state_fp->get());
+    auto const piksi_dns = static_cast<unsigned long long>(1000 * piksi_microdelta_fp->get());
+    auto const time_gps = time_gps_fp->get();
+    auto const time_earth_w = time_earth_w_fp->get();
+
+    /* Handle potential uplinks.
+     *
+     * First, we need to populate the absolute orbital state of the other
+     * spacecraft if there is a currently queued update that's at most two
+     * control cycles past the current time estimate.
+     *
+     * Note these two subtle yet important implementation details:
+     *
+     *  1. A precondition that makes the rest of the control easier to write is
+     *     that the absolute orbit estimate of the other spacecraft is either
+     *     valid and correlating with a time a control cycle ago or invalid. The
+     *     uplinks section is implemented with this in mind hence the potential
+     *     propagation backward in time.
+     *  2. While the uplinks may set the absolute orbital state of the other
+     *     spacecraft, this will be overwritten if the relative estimator is up
+     *     and running alongside a valid orbit estimate. This essentially means
+     *     we're wasting uplinked information; however, that doesn't really
+     *     matter as a direct relative estimate should be more meaningful.
+     */
+    {
+        auto const have_queued_uplink = _uplink_time > get_gps_zero();
+        auto const its_stale = time_gps > _uplink_time;
+
+        if (have_queued_uplink && its_stale)
+        {
+            auto const ns = static_cast<unsigned long long>(time_gps - _uplink_time);
+
+            if (ns < 2u * PAN::control_cycle_time_ns)
+            {
+                auto const signed_ns =
+                        static_cast<unsigned int>(ns) - static_cast<unsigned int>(PAN::control_cycle_time_ns);
+
+                double _;
+                _orbit = orb::Orbit(orb::MINGPSTIME_NS, _uplink_pos, _uplink_vel);
+                _orbit.shortupdate(signed_ns, time_earth_w, _);
+            }
+
+            _uplink_time = get_gps_zero();
+        }
+    }
+    /* Second, check if there is an uplink from the ground that can be moved in
+     * to the queue.
+     */
+    {
+        auto const uplink_time = rel_orbit_uplink_time_f.get();
+
+        auto const have_new_uplink = uplink_time > get_gps_zero();
+        auto const is_in_future = uplink_time > time_gps;
+        auto const is_closer = uplink_time < _uplink_time;
+
+        if (have_new_uplink && is_in_future && is_closer)
+        {
+            _uplink_time = uplink_time;
+            _uplink_pos = rel_orbit_uplink_pos_f.get();
+            _uplink_vel = rel_orbit_uplink_vel_f.get();
+        }
+
+        rel_orbit_uplink_time_f.set(get_gps_zero());
+    }
+
+    auto const orbit_pos = orbit_pos_fp->get();
+    auto const orbit_vel = orbit_vel_fp->get();
+
+    /* Handle the relative orbit estimate.
+     *
+     * Essentially here we will try and update the relative orbit estimate.
+     */
+    switch (piksi_mode)
+    {
+        case piksi_mode_t::fixed_rtk:
+        {
+            auto const piksi_baseline_pos = piksi_baseline_pos_fp->get();
+
+            // If the estimate is already valid, then we run an update step.
+            if (_relative_orbit.valid())
+            {
+                _relative_orbit.update(PAN::control_cycle_time_ns - piksi_dns, time_earth_w,
+                        orbit_pos, orbit_vel, -piksi_baseline_pos, sqrtQ, sqrtR);
+                _relative_orbit.update(piksi_dns, time_earth_w, orbit_pos, orbit_vel, sqrtQ);
+            }
+            // Otherwise, attempt to initialize the estimate.
+            else
+            {
+                if (_have_previous_baseline)
+                {
+                    _previous_baseline_ns += PAN::control_cycle_time_ns;
+
+                    if (_previous_baseline_ns <= 10 * PAN::control_cycle_time_ns)
+                    {
+                        lin::Matrixd<6, 6> S;
+                        lin::ref<lin::Matrix3x3d>(S, 0, 0) = sqrtR;
+                        lin::ref<lin::Matrix3x3d>(S, 3, 3) =
+                                lin::sqrt(2.0e9 / double(_previous_baseline_ns)) * sqrtR;
+
+                        lin::Vector3d baseline_dv =
+                                1.0e9 * (piksi_baseline_pos - _previous_baseline_ns) / double(_previous_baseline_ns);
+
+                        _relative_orbit = gnc::RelativeOrbitEstimate(
+                                time_earth_w, orbit_pos, orbit_vel, -piksi_baseline_pos, -baseline_dv, S);
+
+                        _have_previous_baseline = false;
+                        break;
+                    }
+                }
+                _previous_baseline_pos = piksi_baseline_pos;
+                _previous_baseline_ns = piksi_dns;
+                _have_previous_baseline = true;
+            }
+            break;
+        }
+
+        default:
+        {
+            if (_relative_orbit.valid())
+            {
+                _relative_orbit.update(
+                        PAN::control_cycle_time_ns, time_earth_w, orbit_pos, orbit_vel, sqrtQ);
+            }
+        }
+    }
+
+    /* Mix the relative and absolute orbit measurements.
+     *
+     * At this point, we should have have a potentially up-to-date relative
+     * orbit estimate and/or an up-to-date absolute orbital state for the other
+     * spacecraft. We will favor the relative orbit estimate if present.
+     */
+    if (_relative_orbit.valid())
+    {
+        auto const rel_pos = _relative_orbit.dr_ecef();
+        auto const rel_vel = _relative_orbit.dv_ecef();
+        auto const S = _relative_orbit.S();
+        auto const pos = (orbit_pos + rel_pos).eval();
+        auto const vel = (orbit_vel + rel_vel).eval();
+
+        // Overwrite any uplinked absolute orbit estimate
+        _orbit = orb::Orbit(orb::MINGPSTIME_NS, pos, vel);
+
+        rel_orbit_state_f.set(cast_state(rel_orbit_state_t::estimating));
+
+        rel_orbit_pos_f.set(pos);
+        rel_orbit_vel_f.set(vel);
+
+        rel_orbit_rel_pos_f.set(_relative_orbit.dr_ecef());
+        rel_orbit_rel_pos_sigma_f.set(lin::ref<lin::Vector3d>(lin::diag(S), 0, 0));
+        rel_orbit_rel_vel_f.set(_relative_orbit.dv_ecef());
+        rel_orbit_rel_vel_sigma_f.set(lin::ref<lin::Vector3d>(lin::diag(S), 3, 0));
+    }
+    /* Otherwise, with no relative orbit estimate all we can do is propegate the
+     * absolute estimate if present
+     */
+    else if (_orbit.valid())
+    {
+        double _;
+        _orbit.shortupdate(PAN::control_cycle_time_ns, time_earth_w, _);
+
+        auto const pos = _orbit.recef();
+        auto const vel = _orbit.vecef();
+
+        rel_orbit_state_f.set(cast_state(rel_orbit_state_t::estimating));
+
+        rel_orbit_pos_f.set(pos);
+        rel_orbit_vel_f.set(vel);
+
+        rel_orbit_rel_pos_f.set(pos - orbit_pos);
+        rel_orbit_rel_vel_f.set(vel - orbit_vel);
+    }
+    /* Lastly, if nothing is valid we have an invalid relative orbit estimate.
+     */
+    else
+    {
+        rel_orbit_state_f.set(cast_state(rel_orbit_state_t::invalid));
+    }
+}

--- a/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
+++ b/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
@@ -74,7 +74,7 @@ RelativeOrbitEstimator::RelativeOrbitEstimator(StateFieldRegistry &registry)
     add_readable_field(rel_orbit_rel_pos_sigma_f);
     add_readable_field(rel_orbit_rel_vel_f);
     add_readable_field(rel_orbit_rel_vel_sigma_f);
-    add_writable_field(rel_orbit_uplink_time_f);
+    add_writable_field(rel_orbit_reset_cmd_f);
     add_writable_field(rel_orbit_uplink_time_f);
     add_writable_field(rel_orbit_uplink_pos_f);
     add_writable_field(rel_orbit_uplink_vel_f);

--- a/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
+++ b/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
@@ -316,13 +316,19 @@ void RelativeOrbitEstimator::execute()
         if (_cycles_without_rtk > REL_ORBIT_CC_PREDICT_LIMIT)
         {
             DD("Control cycle predict limit reached for relative orbit "
-               "estimation; resetting the relative estimate.");
-            DD("_orbit.valid() = %i", _orbit.valid());
-            DD("pos=%f,%f,%f vel=%f,%f,%f", orbit_pos(0), orbit_pos(1), orbit_pos(2), orbit_vel(0), orbit_vel(1), orbit_vel(2));
-            DD("rel_pos=%f,%f,%f rel_vel=%f,%f,%f", rel_pos(0), rel_pos(1), rel_pos(2), rel_vel(0), rel_vel(1), rel_vel(2));
+               "estimation; resetting the relative estimate:");
+            DD("\t_orbit.valid() = %i", _orbit.valid());
+            DD("\tpos     = %f,%f,%f", orbit_pos(0), orbit_pos(1), orbit_pos(2));
+            DD("\tvel     = %f,%f,%f", orbit_vel(0), orbit_vel(1), orbit_vel(2));
+            DD("\trel_pos = %f,%f,%f", rel_pos(0), rel_pos(1), rel_pos(2));
+            DD("\trel_vel = %f,%f,%f", rel_vel(0), rel_vel(1), rel_vel(2));
 
             _cycles_without_rtk = 0;
             _relative_orbit = gnc::RelativeOrbitEstimate();
+
+            // We also want to clear any potential uplink as the relative orbit
+            // estimate should be more accurate.
+            _uplink_t = get_gps_zero();
         }
     }
     /* Otherwise, with no relative orbit estimate all we can do is propegate the

--- a/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
+++ b/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
@@ -168,11 +168,13 @@ void RelativeOrbitEstimator::execute()
                 auto const signed_ns =  static_cast<unsigned int>(ns) -
                         static_cast<unsigned int>(PAN::control_cycle_time_ns);
 
-                DD("Initializing absolute orbital state with queued uplink.");
-
                 double _;
                 _orbit = orb::Orbit(orb::MINGPSTIME_NS, _uplink_r, _uplink_v);
                 _orbit.shortupdate(signed_ns, time_earth_w, _);
+
+                DD("Initializing absolute orbital state with queued uplink:");
+                DD("\tr = %f,%f,%f", _uplink_r(0), _uplink_r(1), _uplink_r(2));
+                DD("\tv = %f,%f,%f", _uplink_v(0), _uplink_v(1), _uplink_v(2));
             }
 
             _uplink_t = get_gps_zero();

--- a/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
+++ b/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.cpp
@@ -304,9 +304,9 @@ void RelativeOrbitEstimator::execute()
         rel_orbit_pos_f.set(pos);
         rel_orbit_vel_f.set(vel);
 
-        rel_orbit_rel_pos_f.set(_relative_orbit.dr_ecef());
+        rel_orbit_rel_pos_f.set(rel_pos);
         rel_orbit_rel_pos_sigma_f.set(lin::ref<lin::Vector3d>(lin::diag(S), 0, 0));
-        rel_orbit_rel_vel_f.set(_relative_orbit.dv_ecef());
+        rel_orbit_rel_vel_f.set(rel_vel);
         rel_orbit_rel_vel_sigma_f.set(lin::ref<lin::Vector3d>(lin::diag(S), 3, 0));
 
         /* Limit the number of pure prediction steps we'll do before reverting

--- a/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.hpp
+++ b/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.hpp
@@ -84,12 +84,14 @@ class RelativeOrbitEstimator : public ControlTask<void>
     gnc::RelativeOrbitEstimate _relative_orbit;
     orb::Orbit _orbit;
 
-    gps_time_t _uplink_time;
-    lin::Vector3d _uplink_pos, _uplink_vel;
+    gps_time_t _uplink_t;
+    lin::Vector3d _uplink_r, _uplink_v;
 
     bool _have_previous_baseline;
     lin::Vector3d _previous_baseline_pos;
     unsigned int _previous_baseline_ns;
+
+    unsigned int _cycles_without_rtk;
 };
 
 #endif

--- a/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.hpp
+++ b/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.hpp
@@ -12,6 +12,11 @@
 
 #include <orb/Orbit.h>
 
+/** @author Kyle Krol
+ *
+ *  @brief Provides an estimate of the other spacecraft's position and velocity
+ *         relative to this one.
+ */
 class RelativeOrbitEstimator : public ControlTask<void>
 {
   public:

--- a/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.hpp
+++ b/src/fsw/FCCode/Estimators/RelativeOrbitEstimator.hpp
@@ -1,0 +1,90 @@
+#ifndef ESTIMATORS_RELATIVE_ORBIT_ESTIMATOR_HPP_
+#define ESTIMATORS_RELATIVE_ORBIT_ESTIMATOR_HPP_
+
+#include <common/GPSTime.hpp>
+
+#include <fsw/FCCode/ControlTask.hpp>
+#undef abs
+
+#include <gnc/relative_orbit_estimate.hpp>
+
+#include <lin/core.hpp>
+
+#include <orb/Orbit.h>
+
+class RelativeOrbitEstimator : public ControlTask<void>
+{
+  public:
+    RelativeOrbitEstimator() = delete;
+    RelativeOrbitEstimator(RelativeOrbitEstimator const &) = delete;
+    RelativeOrbitEstimator(RelativeOrbitEstimator &&) = delete;
+    RelativeOrbitEstimator &operator=(RelativeOrbitEstimator const &) = delete;
+    RelativeOrbitEstimator &operator=(RelativeOrbitEstimator &&) = delete;
+
+    ~RelativeOrbitEstimator() = default;
+
+    RelativeOrbitEstimator(StateFieldRegistry &registry);
+
+    void execute() override;
+
+  protected:
+    /* Take position, velocity, relative position, time, time delay, and current
+     * static readings in from Piksi.
+     */
+    ReadableStateField<unsigned char> const *const piksi_state_fp;
+    ReadableStateField<unsigned int> const *const piksi_microdelta_fp;
+    ReadableStateField<lin::Vector3d> const *const piksi_pos_fp;
+    ReadableStateField<lin::Vector3d> const *const piksi_vel_fp;
+    ReadableStateField<lin::Vector3d> const *const piksi_baseline_pos_fp;
+
+    /* Take the current time estimate from the time estimator.
+     */
+    ReadableStateField<bool> const *const time_valid_fp;
+    ReadableStateField<gps_time_t> const *const time_gps_fp;
+    InternalStateField<lin::Vector3d> const *const time_earth_w_fp;
+
+    /* Take the current position and velocity estimates in from the orbit
+     * estimator.
+     */
+    ReadableStateField<bool> const *const orbit_valid_fp;
+    ReadableStateField<lin::Vector3d> const *const orbit_pos_fp;
+    ReadableStateField<lin::Vector3d> const *const orbit_vel_fp;
+
+    /* Outputs for relative position and velocity of the other spacecraft in
+     * ECEF.
+     * 
+     * The estimate's sigma values are valid only if the relative orbit state is
+     * set to estimating.
+     */
+    ReadableStateField<unsigned char> rel_orbit_state_f;
+    ReadableStateField<lin::Vector3d> rel_orbit_pos_f;
+    ReadableStateField<lin::Vector3d> rel_orbit_vel_f;
+    ReadableStateField<lin::Vector3d> rel_orbit_rel_pos_f;
+    ReadableStateField<lin::Vector3d> rel_orbit_rel_pos_sigma_f;
+    ReadableStateField<lin::Vector3d> rel_orbit_rel_vel_f;
+    ReadableStateField<lin::Vector3d> rel_orbit_rel_vel_sigma_f;
+
+    /* Command to forcibly reset the relative orbit estimate.
+     */
+    WritableStateField<bool> rel_orbit_reset_cmd_f;
+
+    /* Uplinks fields for the timestamped position and velocity of the other
+     * spacecraft.
+     */
+    WritableStateField<gps_time_t> rel_orbit_uplink_time_f;
+    WritableStateField<lin::Vector3d> rel_orbit_uplink_pos_f;
+    WritableStateField<lin::Vector3d> rel_orbit_uplink_vel_f;
+
+  private:
+    gnc::RelativeOrbitEstimate _relative_orbit;
+    orb::Orbit _orbit;
+
+    gps_time_t _uplink_time;
+    lin::Vector3d _uplink_pos, _uplink_vel;
+
+    bool _have_previous_baseline;
+    lin::Vector3d _previous_baseline_pos;
+    unsigned int _previous_baseline_ns;
+};
+
+#endif

--- a/src/fsw/FCCode/Estimators/TimeEstimator.cpp
+++ b/src/fsw/FCCode/Estimators/TimeEstimator.cpp
@@ -68,7 +68,10 @@ void TimeEstimator::execute()
 
     if (time_valid_f.get())
     {
-        auto const time_s = static_cast<double>(time_ns_f.get()) * 1.0e-9;
+        time_ns_f.set(static_cast<unsigned long long>(time_gps_f.get()) - gps_epoch_ns);
+        time_s_f.set(static_cast<double>(time_ns_f.get()) * 1.0e-9);
+
+        auto const time_s = time_s_f.get();
         auto const earth_w = [](double t) {
             lin::Vector3d w;
             gnc::env::earth_angular_rate(t, w);
@@ -85,8 +88,6 @@ void TimeEstimator::execute()
             return p;
         }(earth_q_ecef_eci);
 
-        time_ns_f.set(static_cast<unsigned long long>(time_gps_f.get()) - gps_epoch_ns);
-        time_s_f.set(time_s);
         time_earth_w_f.set(earth_w);
         time_earth_q_ecef_eci_f.set(earth_q_ecef_eci);
         time_earth_q_eci_ecef_f.set(earth_q_eci_ecef);

--- a/src/fsw/FCCode/Estimators/TimeEstimator.cpp
+++ b/src/fsw/FCCode/Estimators/TimeEstimator.cpp
@@ -5,6 +5,8 @@
 
 #include <gnc/config.hpp>
 #include <gnc/constants.hpp>
+#include <gnc/environment.hpp>
+#include <gnc/utilities.hpp>
 
 TimeEstimator::TimeEstimator(StateFieldRegistry &registry)
     : ControlTask<void>(registry),
@@ -15,12 +17,18 @@ TimeEstimator::TimeEstimator(StateFieldRegistry &registry)
       time_gps_f("time.gps", Serializer<gps_time_t>()),
       time_ns_f("time.ns"),
       time_s_f("time.s"),
+      time_earth_w_f("time.earth.w"),
+      time_earth_q_ecef_eci_f("time.earth.q_ecef_eci"),
+      time_earth_q_eci_ecef_f("time.earth.q_eci_ecef"),
       time_reset_cmd_f("time.reset_cmd", Serializer<bool>())
 {
     add_readable_field(time_valid_f);
     add_internal_field(time_s_f);
     add_internal_field(time_ns_f);
     add_readable_field(time_gps_f);
+    add_internal_field(time_earth_w_f);
+    add_internal_field(time_earth_q_ecef_eci_f);
+    add_internal_field(time_earth_q_eci_ecef_f);
     add_writable_field(time_reset_cmd_f);
 
     time_valid_f.set(false);
@@ -58,7 +66,29 @@ void TimeEstimator::execute()
             break;
     }
 
-    // Update the other fields (means nothing it time is invalid anyway)
-    time_ns_f.set(static_cast<unsigned long long>(time_gps_f.get()) - gps_epoch_ns);
-    time_s_f.set(static_cast<double>(time_ns_f.get()) * 1.0e-9);
+    if (time_valid_f.get())
+    {
+        auto const time_s = static_cast<double>(time_ns_f.get()) * 1.0e-9;
+        auto const earth_w = [](double t) {
+            lin::Vector3d w;
+            gnc::env::earth_angular_rate(t, w);
+            return w;
+        }(time_s);        
+        auto const earth_q_ecef_eci = [](double t) {
+            lin::Vector4d q;
+            gnc::env::earth_attitude(t, q);
+            return q;
+        }(time_s);
+        auto const earth_q_eci_ecef = [](lin::Vector4d const &q) {
+            lin::Vector4d p;
+            gnc::utl::quat_conj(q, p);
+            return p;
+        }(earth_q_ecef_eci);
+
+        time_ns_f.set(static_cast<unsigned long long>(time_gps_f.get()) - gps_epoch_ns);
+        time_s_f.set(time_s);
+        time_earth_w_f.set(earth_w);
+        time_earth_q_ecef_eci_f.set(earth_q_ecef_eci);
+        time_earth_q_eci_ecef_f.set(earth_q_eci_ecef);
+    }
 }

--- a/src/fsw/FCCode/Estimators/TimeEstimator.hpp
+++ b/src/fsw/FCCode/Estimators/TimeEstimator.hpp
@@ -4,6 +4,7 @@
 #include <common/GPSTime.hpp>
 
 #include <fsw/FCCode/ControlTask.hpp>
+#undef abs
 
 /** @author Kyle Krol
  *
@@ -48,6 +49,13 @@ class TimeEstimator : public ControlTask<void>
     ReadableStateField<gps_time_t> time_gps_f;
     InternalStateField<unsigned long long> time_ns_f;
     InternalStateField<double> time_s_f;
+
+    /* Outputs ephemeris information that's directly tied to the current time
+     * estimate.
+     */
+    InternalStateField<lin::Vector3d> time_earth_w_f;
+    InternalStateField<lin::Vector4d> time_earth_q_ecef_eci_f;
+    InternalStateField<lin::Vector4d> time_earth_q_eci_ecef_f;
 
     /* Command to forcibly reset the time estimate.
      */

--- a/src/fsw/FCCode/Estimators/rel_orbit_state_t.enum
+++ b/src/fsw/FCCode/Estimators/rel_orbit_state_t.enum
@@ -1,0 +1,11 @@
+#ifndef rel_orbit_state_t_enum_
+#define rel_orbit_state_t_enum_
+
+// rel_orbit.state
+enum class rel_orbit_state_t : unsigned char {
+    invalid = 0,
+    propagating,
+    estimating
+};
+
+#endif

--- a/test/test_fsw_estimators_relative_orbit_estimator/test_fsw_estimators_relative_orbit_estimator.cpp
+++ b/test/test_fsw_estimators_relative_orbit_estimator/test_fsw_estimators_relative_orbit_estimator.cpp
@@ -12,6 +12,13 @@
 
 #include <lin/core.hpp>
 
+#include <orb/Orbit.h>
+
+static auto const pan_epoch = gps_time_t(gnc::constant::init_gps_week_number,
+            gnc::constant::init_gps_time_of_week, gnc::constant::init_gps_nanoseconds);
+static constexpr lin::Vector3d r_ecef = {6.8538e6, 0.0, 0.0};
+static constexpr lin::Vector3d v_ecef = {0.0, 4.8954e3, 5.3952e3};
+
 class TestFixture
 {
   public:
@@ -30,6 +37,7 @@ class TestFixture
     ReadableStateField<gps_time_t> const *const time_gps_fp;
     InternalStateField<unsigned long long> const *const time_ns_fp;
     InternalStateField<double> const *const time_s_fp;
+    InternalStateField<lin::Vector3d> const *const time_earth_w_fp;
     WritableStateField<bool> *const time_reset_cmd_fp;
 
     OrbitEstimator orbit_estimator;
@@ -66,6 +74,7 @@ class TestFixture
           time_gps_fp(registry.find_readable_field_t<gps_time_t>("time.gps")),
           time_ns_fp(registry.find_internal_field_t<unsigned long long>("time.ns")),
           time_s_fp(registry.find_internal_field_t<double>("time.s")),
+          time_earth_w_fp(registry.find_internal_field_t<lin::Vector3d>("time.earth.w")),
           time_reset_cmd_fp(registry.find_writable_field_t<bool>("time.reset_cmd")),
           orbit_estimator(registry),
           orbit_valid_fp(registry.find_readable_field_t<bool>("orbit.valid")),
@@ -85,12 +94,29 @@ class TestFixture
           rel_orbit_uplink_pos_fp(registry.find_writable_field_t<lin::Vector3d>("rel_orbit.uplink.pos")),
           rel_orbit_uplink_vel_fp(registry.find_writable_field_t<lin::Vector3d>("rel_orbit.uplink.vel"))
     { }
-};
 
-static auto const pan_epoch = gps_time_t(gnc::constant::init_gps_week_number,
-            gnc::constant::init_gps_time_of_week, gnc::constant::init_gps_nanoseconds);
-static constexpr lin::Vector3d r_ecef = {6.8538e6, 0.0, 0.0};
-static constexpr lin::Vector3d v_ecef = {0.0, 4.8954e3, 5.3952e3};
+    void initialize_time_and_orbit_estimates()
+    {
+        piksi_mode_fp->set(static_cast<unsigned char>(piksi_mode_t::spp));
+        piksi_microdelta_fp->set(0);
+        piksi_time_fp->set(pan_epoch);
+        piksi_pos_fp->set(r_ecef);
+        piksi_vel_fp->set(v_ecef);
+
+        time_estimator.execute();
+        orbit_estimator.execute();
+
+        TEST_ASSERT_TRUE(time_valid_fp->get());
+        TEST_ASSERT_TRUE(orbit_valid_fp->get());
+    }
+
+    void execute()
+    {
+        time_estimator.execute();
+        orbit_estimator.execute();
+        relative_orbit_estimator.execute();
+    }
+};
 
 void test_constructor()
 {
@@ -101,77 +127,107 @@ void test_constructor()
     TEST_ASSERT_FALSE(tf.rel_orbit_reset_cmd_fp->get());
 }
 
-void test_uplink()
+void test_stale_uplinks()
 {
     TestFixture tf;
+    tf.initialize_time_and_orbit_estimates();
 
-    // Initialize a time and orbit estimate
-    tf.piksi_mode_fp->set(static_cast<unsigned char>(piksi_mode_t::spp));
-    tf.piksi_microdelta_fp->set(0);
-    tf.piksi_time_fp->set(pan_epoch);
-    tf.piksi_pos_fp->set(r_ecef);
-    tf.piksi_vel_fp->set(v_ecef);
+    tf.rel_orbit_uplink_time_fp->set(tf.time_gps_fp->get() - PAN::control_cycle_time_ns);
+    tf.rel_orbit_uplink_pos_fp->set(r_ecef);
+    tf.rel_orbit_uplink_vel_fp->set(v_ecef);
+
+    tf.relative_orbit_estimator.execute(); // Takes two cycles to initialize
+    tf.relative_orbit_estimator.execute();
+
+    TEST_ASSERT_FALSE(tf.rel_orbit_state_fp->get());
+    TEST_ASSERT_TRUE(tf.rel_orbit_uplink_time_fp->get() == gps_time_t(0, 0, 0));
+}
+
+void test_valid_uplinks()
+{
+    TestFixture tf;
+    tf.initialize_time_and_orbit_estimates();
+
+    double _;
+    orb::Orbit orbit(orb::MINGPSTIME_NS, r_ecef, v_ecef);
+    orbit.shortupdate(PAN::control_cycle_time_ns, tf.time_earth_w_fp->get(), _);
+
+    tf.piksi_mode_fp->set(static_cast<unsigned char>(piksi_mode_t::no_fix));
+    tf.rel_orbit_uplink_time_fp->set(tf.time_gps_fp->get() + PAN::control_cycle_time_ns);
+    tf.rel_orbit_uplink_pos_fp->set(orbit.recef());
+    tf.rel_orbit_uplink_vel_fp->set(orbit.vecef());
+
+    tf.relative_orbit_estimator.execute();
+
+    // Uplink should have been moved to the queue
+    TEST_ASSERT_TRUE(tf.rel_orbit_uplink_time_fp->get() == gps_time_t(0, 0, 0));
+
+    tf.execute(); // Two cycles to move the relative orbit estimator to
+    tf.execute(); // propagating.
+
+    orbit.shortupdate(PAN::control_cycle_time_ns, tf.time_earth_w_fp->get(), _);
+
+    TEST_ASSERT_TRUE(tf.time_gps_fp->get() == pan_epoch + 2u * PAN::control_cycle_time_ns);
+    TEST_ASSERT_EQUAL(static_cast<unsigned char>(rel_orbit_state_t::propagating), tf.rel_orbit_state_fp->get());
+    TEST_ASSERT_DOUBLE_WITHIN(1.0e-3, 0.0, lin::fro(tf.rel_orbit_pos_fp->get() - orbit.recef()));
+    TEST_ASSERT_DOUBLE_WITHIN(1.0e-3, 0.0, lin::fro(tf.rel_orbit_vel_fp->get() - orbit.vecef()));
+
+    tf.execute();
+    tf.execute();
+
+    TEST_ASSERT_EQUAL(static_cast<unsigned char>(rel_orbit_state_t::propagating), tf.rel_orbit_state_fp->get());
+}
+
+void test_relative_estimation()
+{
+    TestFixture tf;
+    tf.initialize_time_and_orbit_estimates();
+
+    // Give the relative orbit estimate it's first RTK reading
+    tf.piksi_mode_fp->set(static_cast<unsigned char>(piksi_mode_t::fixed_rtk));
+    tf.piksi_baseline_pos_fp->set({5.0, 0.0, 0.0});
+
+    tf.relative_orbit_estimator.execute();
+
+    // Force the time and orbit estimators to just predict
+    tf.piksi_mode_fp->set(static_cast<unsigned char>(piksi_mode_t::no_fix));
 
     tf.time_estimator.execute();
     tf.orbit_estimator.execute();
 
-    TEST_ASSERT_TRUE(tf.time_valid_fp->get());
-    TEST_ASSERT_TRUE(tf.orbit_valid_fp->get());
+    // Give the relative orbit estimate it's second RTK reading
+    tf.piksi_mode_fp->set(static_cast<unsigned char>(piksi_mode_t::fixed_rtk));
+    tf.piksi_baseline_pos_fp->set({5.05, 0.0, 0.0});
 
-    // Check the an uplink is required to initialize the relative orbit estimate
-    // in propegating mode
-    tf.relative_orbit_estimator.execute();
     tf.relative_orbit_estimator.execute();
 
-    TEST_ASSERT_FALSE(tf.rel_orbit_state_fp->get());
+    TEST_ASSERT_EQUAL(static_cast<unsigned char>(rel_orbit_state_t::estimating), tf.rel_orbit_state_fp->get());
+    TEST_ASSERT_DOUBLE_WITHIN(1.0e-4, 0.0,
+            lin::fro(tf.rel_orbit_rel_pos_fp->get() - lin::Vector3d({{-5.05, 0.0, 0.0}})));
 
-    tf.rel_orbit_uplink_pos_fp->set(r_ecef);
-    tf.rel_orbit_uplink_vel_fp->set(v_ecef);
+    // Test the relative orbit estimator's predict limit
+    tf.piksi_mode_fp->set(static_cast<unsigned char>(piksi_mode_t::no_fix));
 
-    // Given an uplink in the future ensure we don't initialize right away
-    tf.rel_orbit_uplink_time_fp->set(pan_epoch + PAN::control_cycle_time_ns);
+    for (auto i = 0; i < 5000; i++) tf.execute(); // Cycle through the CC limit
 
-    tf.relative_orbit_estimator.execute();  // Takes two cycles to happen
-    tf.relative_orbit_estimator.execute();
+    // Last control cycle that will be estimating
+    tf.execute();
 
-    TEST_ASSERT_FALSE(tf.rel_orbit_state_fp->get());
+    TEST_ASSERT_EQUAL(static_cast<unsigned char>(rel_orbit_state_t::estimating), tf.rel_orbit_state_fp->get());
 
-    // Given a stale uplink ensure we don't initialize
-    tf.rel_orbit_uplink_time_fp->set(pan_epoch - 3u * PAN::control_cycle_time_ns);
+    // Next control cycle will be propagating
+    tf.execute();
 
-    tf.relative_orbit_estimator.execute(); // Takes two cycles to happen
-    tf.relative_orbit_estimator.execute();
-
-    TEST_ASSERT_FALSE(tf.rel_orbit_state_fp->get());
-
-    // Given a valid orbital uplink check everything gets initialized
-    tf.rel_orbit_uplink_time_fp->set(pan_epoch - PAN::control_cycle_time_ns);
-
-    tf.relative_orbit_estimator.execute(); // Takes two cycles to happen
-    tf.relative_orbit_estimator.execute(); // This propegates forward by PAN
-
-    TEST_ASSERT_EQUAL(tf.rel_orbit_state_fp->get(), static_cast<unsigned char>(rel_orbit_state_t::propagating));
-    // Note that the two orbits are nearly identical
-    TEST_ASSERT_DOUBLE_WITHIN(10.0, lin::fro(tf.rel_orbit_rel_pos_fp->get()), 0.0);
-    TEST_ASSERT_DOUBLE_WITHIN(1.00, lin::fro(tf.rel_orbit_rel_vel_fp->get()), 0.0);
-    TEST_ASSERT_DOUBLE_WITHIN(10.0, lin::fro(tf.rel_orbit_pos_fp->get() - r_ecef), 0.0);
-    TEST_ASSERT_DOUBLE_WITHIN(1.00, lin::fro(tf.rel_orbit_vel_fp->get() - v_ecef), 0.0);
-
-    // Ensure it will continue propegating over time
-    tf.relative_orbit_estimator.execute();
-    tf.relative_orbit_estimator.execute();
-    tf.relative_orbit_estimator.execute();
-    tf.relative_orbit_estimator.execute();
-    tf.relative_orbit_estimator.execute();
-
-    TEST_ASSERT_EQUAL(tf.rel_orbit_state_fp->get(), static_cast<unsigned char>(rel_orbit_state_t::propagating));
+    TEST_ASSERT_EQUAL(static_cast<unsigned char>(rel_orbit_state_t::propagating), tf.rel_orbit_state_fp->get());
 }
 
 int test_control_task()
 {
     UNITY_BEGIN();
     RUN_TEST(test_constructor);
-    RUN_TEST(test_uplink);
+    RUN_TEST(test_stale_uplinks);
+    RUN_TEST(test_valid_uplinks);
+    RUN_TEST(test_relative_estimation);
     return UNITY_END();
 }
 

--- a/test/test_fsw_estimators_relative_orbit_estimator/test_fsw_estimators_relative_orbit_estimator.cpp
+++ b/test/test_fsw_estimators_relative_orbit_estimator/test_fsw_estimators_relative_orbit_estimator.cpp
@@ -1,0 +1,127 @@
+#include "../custom_assertions.hpp"
+#include "../StateFieldRegistryMock.hpp"
+
+#include <gnc/constants.hpp>
+
+#include <fsw/FCCode/constants.hpp>
+#include <fsw/FCCode/Estimators/OrbitEstimator.hpp>
+#include <fsw/FCCode/Estimators/RelativeOrbitEstimator.hpp>
+#include <fsw/FCCode/Estimators/rel_orbit_state_t.enum>
+#include <fsw/FCCode/Estimators/TimeEstimator.hpp>
+#include <fsw/FCCode/piksi_mode_t.enum>
+
+#include <lin/core.hpp>
+
+class TestFixture
+{
+  public:
+    StateFieldRegistryMock registry;
+
+    std::shared_ptr<ReadableStateField<unsigned char>> piksi_mode_fp;
+    std::shared_ptr<ReadableStateField<unsigned int>> piksi_microdelta_fp;
+    std::shared_ptr<ReadableStateField<gps_time_t>> piksi_time_fp;
+    std::shared_ptr<ReadableStateField<lin::Vector3d>> piksi_pos_fp;
+    std::shared_ptr<ReadableStateField<lin::Vector3d>> piksi_vel_fp;
+    std::shared_ptr<ReadableStateField<lin::Vector3d>> piksi_baseline_pos_fp;
+
+    TimeEstimator time_estimator;
+
+    ReadableStateField<bool> const *const time_valid_fp;
+    ReadableStateField<gps_time_t> const *const time_gps_fp;
+    InternalStateField<unsigned long long> const *const time_ns_fp;
+    InternalStateField<double> const *const time_s_fp;
+    WritableStateField<bool> *const time_reset_cmd_fp;
+
+    OrbitEstimator orbit_estimator;
+
+    ReadableStateField<bool> const *const orbit_valid_fp;
+    ReadableStateField<lin::Vector3d> const *const orbit_pos_fp;
+    ReadableStateField<lin::Vector3d> const *const orbit_vel_fp;
+    WritableStateField<bool> *const orbit_reset_cmd_fp;
+
+    RelativeOrbitEstimator relative_orbit_estimator;
+
+    ReadableStateField<unsigned char> const *const rel_orbit_state_fp;
+    ReadableStateField<lin::Vector3d> const *const rel_orbit_pos_fp;
+    ReadableStateField<lin::Vector3d> const *const rel_orbit_vel_fp;
+    ReadableStateField<lin::Vector3d> const *const rel_orbit_rel_pos_fp;
+    ReadableStateField<lin::Vector3d> const *const rel_orbit_rel_pos_sigma_fp;
+    ReadableStateField<lin::Vector3d> const *const rel_orbit_rel_vel_fp;
+    ReadableStateField<lin::Vector3d> const *const rel_orbit_rel_vel_sigma_fp;
+    WritableStateField<bool> *const rel_orbit_reset_cmd_fp;
+    WritableStateField<gps_time_t> *const rel_orbit_uplink_time_fp;
+    WritableStateField<lin::Vector3d> *const rel_orbit_uplink_pos_fp;
+    WritableStateField<lin::Vector3d> *const rel_orbit_uplink_vel_fp;
+
+    TestFixture()
+        : registry(),
+          piksi_mode_fp(registry.create_readable_field<unsigned char>("piksi.state")),
+          piksi_microdelta_fp(registry.create_readable_field<unsigned int>("piksi.microdelta")),
+          piksi_time_fp(registry.create_readable_field<gps_time_t>("piksi.time")),
+          piksi_pos_fp(registry.create_readable_lin_vector_field<double>("piksi.pos", 6771000, 6921000, 28)),
+          piksi_vel_fp(registry.create_readable_lin_vector_field<double>("piksi.vel", 7570, 7685, 19)),
+          piksi_baseline_pos_fp(registry.create_readable_lin_vector_field<double>("piksi.baseline_pos", 0, 2000, 22)),
+          time_estimator(registry),
+          time_valid_fp(registry.find_readable_field_t<bool>("time.valid")),
+          time_gps_fp(registry.find_readable_field_t<gps_time_t>("time.gps")),
+          time_ns_fp(registry.find_internal_field_t<unsigned long long>("time.ns")),
+          time_s_fp(registry.find_internal_field_t<double>("time.s")),
+          time_reset_cmd_fp(registry.find_writable_field_t<bool>("time.reset_cmd")),
+          orbit_estimator(registry),
+          orbit_valid_fp(registry.find_readable_field_t<bool>("orbit.valid")),
+          orbit_pos_fp(registry.find_readable_field_t<lin::Vector3d>("orbit.pos")),
+          orbit_vel_fp(registry.find_readable_field_t<lin::Vector3d>("orbit.vel")),
+          orbit_reset_cmd_fp(registry.find_writable_field_t<bool>("orbit.reset_cmd")),
+          relative_orbit_estimator(registry),
+          rel_orbit_state_fp(registry.find_readable_field_t<unsigned char>("rel_orbit.state")),
+          rel_orbit_pos_fp(registry.find_readable_field_t<lin::Vector3d>("rel_orbit.pos")),
+          rel_orbit_vel_fp(registry.find_readable_field_t<lin::Vector3d>("rel_orbit.vel")),
+          rel_orbit_rel_pos_fp(registry.find_readable_field_t<lin::Vector3d>("rel_orbit.rel_pos")),
+          rel_orbit_rel_pos_sigma_fp(registry.find_readable_field_t<lin::Vector3d>("rel_orbit.rel_pos_sigma")),
+          rel_orbit_rel_vel_fp(registry.find_readable_field_t<lin::Vector3d>("rel_orbit.rel_vel")),
+          rel_orbit_rel_vel_sigma_fp(registry.find_readable_field_t<lin::Vector3d>("rel_orbit.rel_vel_sigma")),
+          rel_orbit_reset_cmd_fp(registry.find_writable_field_t<bool>("rel_orbit.reset_cmd")),
+          rel_orbit_uplink_time_fp(registry.find_writable_field_t<gps_time_t>("rel_orbit.uplink.time")),
+          rel_orbit_uplink_pos_fp(registry.find_writable_field_t<lin::Vector3d>("rel_orbit.uplink.pos")),
+          rel_orbit_uplink_vel_fp(registry.find_writable_field_t<lin::Vector3d>("rel_orbit.uplink.vel"))
+    { }
+};
+
+static auto const pan_epoch = gps_time_t(gnc::constant::init_gps_week_number,
+            gnc::constant::init_gps_time_of_week, gnc::constant::init_gps_nanoseconds);
+static constexpr lin::Vector3d r_ecef = {6.8538e6, 0.0, 0.0};
+static constexpr lin::Vector3d v_ecef = {0.0, 5.3952e3, 5.3952e3};
+
+void test_constructor()
+{
+    TestFixture tf;
+
+    // By default, the valid flag and reset command should be false
+    TEST_ASSERT_FALSE(tf.rel_orbit_state_fp->get());
+    TEST_ASSERT_FALSE(tf.rel_orbit_reset_cmd_fp->get());
+}
+
+int test_control_task()
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_constructor);
+    return UNITY_END();
+}
+
+#ifdef DESKTOP
+int main()
+{
+    return test_control_task();
+}
+#else
+#include <Arduino.h>
+void setup()
+{
+    delay(2000);
+    Serial.begin(9600);
+    test_control_task();
+}
+
+void loop()
+{ }
+#endif


### PR DESCRIPTION
# Relative Orbit Estimator

Closes #656.
Closes #606.
Relates to #349.

### Summary of changes

- Added a relative orbit estimation class that's responsible for handling orbital uplinks and Piksi RTK data.

### Testing

Added a unit test to step through initialization, comms uplink testing, et cetera. The real test, however, is going to be with psim in the loop and fully spoofed sensor data.

### Constants

Added constants for the CDGPS sensor noise, relative orbit estimator process noise, and a control cycle timeout count for the relative orbit estimator.

### Telemetry

No changes until the new control tasks are integrated with flight software.

### Documentation Evidence

Will be posting and update description of how the orbit control tasks work to #349.
