### PR TITLE
Fix piksi control task test

### DIFF
--- a/src/fsw/FCCode/Drivers/Piksi.cpp
+++ b/src/fsw/FCCode/Drivers/Piksi.cpp
@@ -233,6 +233,9 @@ void Piksi::set_baseline_flag(const unsigned char flag){
 void Piksi::set_read_return(const unsigned int out){
     _read_return = out;
 }
+void Piksi::set_microdelta(unsigned long udelta){
+    microdelta = udelta;
+}
 #endif
 
 unsigned int Piksi::get_iar() { return _iar.num_hyps; }

--- a/src/fsw/FCCode/Drivers/Piksi.hpp
+++ b/src/fsw/FCCode/Drivers/Piksi.hpp
@@ -224,6 +224,7 @@ class Piksi {
     void set_baseline_ecef(const unsigned int tow, const std::array<double, 3>& position);
     void set_baseline_flag(const unsigned char flag);
     void set_read_return(const unsigned int out);
+    void set_microdelta(unsigned long udelta);
     #endif
 
     /** @brief Reads current settings in Piksi RAM.

--- a/src/fsw/FCCode/PiksiControlTask.cpp
+++ b/src/fsw/FCCode/PiksiControlTask.cpp
@@ -46,8 +46,8 @@ void PiksiControlTask::execute()
     unsigned int microdelta = piksi.get_microdelta();
     microdelta_f.set(microdelta);
 
-    //Throw CRC error if microdelta is not in expected range
-    if (microdelta > PIKSI_MD_THRESHOLD) read_out = 3; 
+    //Throw CRC error if microdelta is not in expected range and no other error is thrown
+    if (microdelta > PIKSI_MD_THRESHOLD && read_out < 2) read_out = 3; 
 
     //4 means no bytes
     //3 means CRC error on serial

--- a/test/test_fsw_piksi_control_task/test_piksi_control_task.cpp
+++ b/test/test_fsw_piksi_control_task/test_piksi_control_task.cpp
@@ -75,6 +75,9 @@ class TestFixture {
         void set_baseline_flag(const unsigned char flag){
                 piksi_task->piksi.set_baseline_flag(flag);
         }
+        void set_microdelta(unsigned long udelta){
+                piksi_task->piksi.set_microdelta(udelta);
+        }
 };
 
 void test_task_initialization()
@@ -125,6 +128,7 @@ void test_normal_errors(){
         tf.set_vel_ecef(tow, vel);
         tf.set_baseline_ecef(tow, baseline);
         tf.set_baseline_flag(1);
+        tf.set_microdelta(0);
         tf.execute();
         //should error out because of time inconsistency
         assert_piksi_mode(piksi_mode_t::sync_error);
@@ -175,6 +179,7 @@ void test_task_execute()
         tf.set_vel_ecef(tow, vel);
         tf.set_baseline_ecef(tow, baseline);
         tf.set_baseline_flag(1);
+        tf.set_microdelta(0);
         tf.execute();
         //times should now agree, and be in baseline
         assert_piksi_mode(piksi_mode_t::fixed_rtk);
@@ -236,6 +241,7 @@ void test_dead(){
         tf.set_vel_ecef(tow, vel);
         tf.set_baseline_ecef(tow, baseline);
         tf.set_baseline_flag(1);
+        tf.set_microdelta(0);
         tf.execute();
         //times should now agree, and be in baseline
         assert_piksi_mode(piksi_mode_t::fixed_rtk);

--- a/test/test_fsw_piksi_control_task/test_piksi_control_task.cpp
+++ b/test/test_fsw_piksi_control_task/test_piksi_control_task.cpp
@@ -141,6 +141,7 @@ void test_normal_errors(){
         tf.set_vel_ecef(tow, vel);
         tf.set_baseline_ecef(tow, baseline);
         tf.set_baseline_flag(1);
+        tf.set_microdelta(0);
         tf.execute();
         //times agree, but insufficient nsat
         assert_piksi_mode(piksi_mode_t::nsat_error);
@@ -153,6 +154,7 @@ void test_normal_errors(){
         tf.set_vel_ecef(tow, vel);
         tf.set_baseline_ecef(tow, baseline);
         tf.set_baseline_flag(2);
+        tf.set_microdelta(0);
         tf.execute();
         //times agree, but insufficient nsat
         assert_piksi_mode(piksi_mode_t::data_error);
@@ -200,6 +202,7 @@ void test_task_execute()
         tf.set_vel_ecef(tow, vel);
         tf.set_baseline_ecef(tow, baseline);
         tf.set_baseline_flag(0);
+        tf.set_microdelta(0);
         tf.execute();
         //float rtk test
         assert_piksi_mode(piksi_mode_t::float_rtk);


### PR DESCRIPTION
# Fixes failures in testing piksi control task in fsw_native_leader

Fixes #682

### Summary of changes
- set microdelta crc error so it doesn't override other important errors
- add set_microdelta function to piksi driver
- set microdelta as 0 before piksi control task unit tests 


### Testing
- passes all the tests in test_fsw_piksi_control_task

### Documentation Evidence
- inline
