### PR TITLE
Enum Print

### DIFF
--- a/ptest/cases/utils.py
+++ b/ptest/cases/utils.py
@@ -221,7 +221,7 @@ class Enums(object):
             "adcs.state" : self.adcs_states,
             "radio.state" : self.radio_states,
             "sat.designation" : self.sat_designations,
-            "piksi.mode" : self.piksi_modes,
+            "piksi.state" : self.piksi_modes,
         }
         return key_associations[key]
 

--- a/ptest/cmdprompt.py
+++ b/ptest/cmdprompt.py
@@ -114,11 +114,17 @@ class StateCmdPrompt(Cmd):
             return
 
         start_time = timeit.default_timer()
-        read_result = self.cmded_device.read_state(args[0])
+        try:
+            read_result = self.cmded_device.smart_read(args[0])
+        except NameError:
+            read_result = None
+            print('Field with that name does not exist!')
+            return 
+            
         elapsed_time = int((timeit.default_timer() - start_time) * 1E6)
 
         try:
-            human_readable_result = Enums()[args[0]]
+            human_readable_result = Enums()[args[0]][read_result]
             print(f"{read_result} ({human_readable_result}) \t\t\t\t\t\t(Completed in {elapsed_time} us)")
         except KeyError:
             # args[0] is not an enum field.


### PR DESCRIPTION
# PTest Enum Print Support

### Summary of changes
- Enum printing is now supported so long as it is defined as appropriate in `utils.py`
- If in the ptest terminal, you try to read a field that doesn't exist, you'll get a slightly more verbose message now.
- Tested and working
