### PR TITLE
yikes

### DIFF
--- a/ptest/usb_session.py
+++ b/ptest/usb_session.py
@@ -397,10 +397,10 @@ class USBSession(object):
         if success and os.path.exists("uplink.sbd"):
             success &= self.send_uplink("uplink.sbd")
             os.remove("uplink.sbd") 
-            os.remove("uplink.json") 
+            os.remove("uplink.http") 
             return success
         else:
-            if os.path.exists("uplink.json"): os.remove("uplink.json") 
+            if os.path.exists("uplink.json"): os.remove("uplink.http") 
             return False
 
     def parsetelem(self):
@@ -468,7 +468,12 @@ class USBSession(object):
         uplinks directed to this satellite to the Flight Computer
         '''
         #look for all new emails from iridium
-        self.mail.select('"[Gmail]/Sent Mail"')
+        try:
+            self.mail.select('"[Gmail]/Sent Mail"')
+        except:
+            self.mail = imaplib.IMAP4_SSL("imap.gmail.com", 993)
+            self.mail.login(self.username, self.password)
+            self.mail.select('"[Gmail]/Sent Mail"')
         _, data = self.mail.search(None, '(FROM "pan.ssds.qlocate@gmail.com")', '(UNSEEN)')
         mail_ids = data[0]
         id_list = mail_ids.split()


### PR DESCRIPTION
# Fix USB Session

### Summary of changes
- It seems we accidentally misnamed the file to remove in `uplink()`.
- I've been getting some errors in USB session when scraping uplinks, where there was some trouble connecting to email. I found that this could be fixed simply by trying to reconnect to email. No one else has gotten this error so far, and I didn't ever get this error until the last work session. However, it can't hurt to include it in case it does come up again.