### PR TITLE
fork vs spawn

### DIFF
--- a/ptest/runsim.py
+++ b/ptest/runsim.py
@@ -9,6 +9,9 @@ from .uplink_console import UplinkConsole
 from .cmdprompt import StateCmdPrompt
 from . import get_pio_asset
 import json, sys, os, time, threading
+import multiprocessing
+multiprocessing.set_start_method('fork') 
+
 
 try:
     import pty, subprocess

--- a/ptest/usb_session.py
+++ b/ptest/usb_session.py
@@ -8,7 +8,6 @@ import os
 import pty
 import subprocess
 import multiprocessing
-multiprocessing.set_start_method('fork') 
 import glob
 from elasticsearch import Elasticsearch
 import email

--- a/ptest/usb_session.py
+++ b/ptest/usb_session.py
@@ -117,7 +117,7 @@ class USBSession(object):
             self.flask_app = create_usb_session_endpoint(self)
             self.flask_app.config["uplink_console"] = self.uplink_console
             self.flask_app.config["console"] = self.console
-            self.http_thread = Process(name=f"{self.device_name} HTTP Command Endpoint", target=self.flask_app.run, kwargs={"host":'0.0.0.0', "port": self.port})
+            self.http_thread = multiprocessing.Process(name=f"{self.device_name} HTTP Command Endpoint", target=self.flask_app.run, kwargs={"host":'0.0.0.0', "port": self.port})
             self.http_thread.start()
             print(f"{self.device_name} HTTP command endpoint is running at http://localhost:{self.port}")
             return True

--- a/ptest/usb_session.py
+++ b/ptest/usb_session.py
@@ -114,13 +114,17 @@ class USBSession(object):
             print(f"Unable to open serial port for {self.device_name}.")
             return False
 
-        self.flask_app = create_usb_session_endpoint(self)
-        self.flask_app.config["uplink_console"] = self.uplink_console
-        self.flask_app.config["console"] = self.console
-        self.http_thread = multiprocessing.Process(name=f"{self.device_name} HTTP Command Endpoint", target=self.flask_app.run, kwargs={"host":'0.0.0.0', "port": self.port})
-        self.http_thread.start()
-        print(f"{self.device_name} HTTP command endpoint is running at http://localhost:{self.port}")
-        return True
+        try:
+            self.flask_app = create_usb_session_endpoint(self)
+            self.flask_app.config["uplink_console"] = self.uplink_console
+            self.flask_app.config["console"] = self.console
+            self.http_thread = Process(name=f"{self.device_name} HTTP Command Endpoint", target=self.flask_app.run, kwargs={"host":'0.0.0.0', "port": self.port})
+            self.http_thread.start()
+            print(f"{self.device_name} HTTP command endpoint is running at http://localhost:{self.port}")
+            return True
+        except:
+            print(f"Unable to start {self.device_name} HTTP command endpoint at http://localhost:{self.port}")
+            return False
 
     def check_console_msgs(self):
         '''

--- a/ptest/usb_session.py
+++ b/ptest/usb_session.py
@@ -114,7 +114,6 @@ class USBSession(object):
             print(f"Unable to open serial port for {self.device_name}.")
             return False
 
-        
         self.flask_app = create_usb_session_endpoint(self)
         self.flask_app.config["uplink_console"] = self.uplink_console
         self.flask_app.config["console"] = self.console

--- a/ptest/usb_session.py
+++ b/ptest/usb_session.py
@@ -7,7 +7,7 @@ import queue
 import os
 import pty
 import subprocess
-import multiprocessing
+from multiprocessing import Process
 import glob
 from elasticsearch import Elasticsearch
 import email
@@ -117,7 +117,7 @@ class USBSession(object):
             self.flask_app = create_usb_session_endpoint(self)
             self.flask_app.config["uplink_console"] = self.uplink_console
             self.flask_app.config["console"] = self.console
-            self.http_thread = multiprocessing.Process(name=f"{self.device_name} HTTP Command Endpoint", target=self.flask_app.run, kwargs={"host":'0.0.0.0', "port": self.port})
+            self.http_thread = Process(name=f"{self.device_name} HTTP Command Endpoint", target=self.flask_app.run, kwargs={"host":'0.0.0.0', "port": self.port})
             self.http_thread.start()
             print(f"{self.device_name} HTTP command endpoint is running at http://localhost:{self.port}")
             return True
@@ -532,11 +532,11 @@ class USBSession(object):
         self.console.close()
         self.dp_console.close()
 
-        # self.http_thread.terminate()
-        # self.http_thread.join()
+        self.http_thread.terminate()
+        self.http_thread.join()
 
-        # self.http_thread.terminate()
-        # self.http_thread.join()
+        self.http_thread.terminate()
+        self.http_thread.join()
 
         self.datastore.stop()
         self.logger.stop()

--- a/ptest/usb_session.py
+++ b/ptest/usb_session.py
@@ -7,7 +7,8 @@ import queue
 import os
 import pty
 import subprocess
-from multiprocessing import Process
+import multiprocessing
+multiprocessing.set_start_method('fork') 
 import glob
 from elasticsearch import Elasticsearch
 import email
@@ -113,17 +114,14 @@ class USBSession(object):
             print(f"Unable to open serial port for {self.device_name}.")
             return False
 
-        try:
-            self.flask_app = create_usb_session_endpoint(self)
-            self.flask_app.config["uplink_console"] = self.uplink_console
-            self.flask_app.config["console"] = self.console
-            self.http_thread = Process(name=f"{self.device_name} HTTP Command Endpoint", target=self.flask_app.run, kwargs={"host":'0.0.0.0', "port": self.port})
-            self.http_thread.start()
-            print(f"{self.device_name} HTTP command endpoint is running at http://localhost:{self.port}")
-            return True
-        except:
-            print(f"Unable to start {self.device_name} HTTP command endpoint at http://localhost:{self.port}")
-            return False
+        
+        self.flask_app = create_usb_session_endpoint(self)
+        self.flask_app.config["uplink_console"] = self.uplink_console
+        self.flask_app.config["console"] = self.console
+        self.http_thread = multiprocessing.Process(name=f"{self.device_name} HTTP Command Endpoint", target=self.flask_app.run, kwargs={"host":'0.0.0.0', "port": self.port})
+        self.http_thread.start()
+        print(f"{self.device_name} HTTP command endpoint is running at http://localhost:{self.port}")
+        return True
 
     def check_console_msgs(self):
         '''
@@ -532,11 +530,11 @@ class USBSession(object):
         self.console.close()
         self.dp_console.close()
 
-        self.http_thread.terminate()
-        self.http_thread.join()
+        # self.http_thread.terminate()
+        # self.http_thread.join()
 
-        self.http_thread.terminate()
-        self.http_thread.join()
+        # self.http_thread.terminate()
+        # self.http_thread.join()
 
         self.datastore.stop()
         self.logger.stop()


### PR DESCRIPTION
**Fork vs Spawn**

**Fixes**
Imported the multiprocessing library and the changed multiprocessing to start with fork instead of spawn, which after Python 3.8 began defaulting to spawn and caused errors with ptesting. 

**Summary of changes**
- Changed import statements for usb_session.py and runsim.py
- Added fork to default call for runsim.py

**Documentation Evidence**
<img width="1251" alt="Screen Shot 2021-04-10 at 1 33 45 AM" src="https://user-images.githubusercontent.com/65980474/114259956-c6daa600-999f-11eb-999a-f0cf1515975d.png">

**Post Fix:**

<img width="887" alt="Screen Shot 2021-04-10 at 1 59 27 AM" src="https://user-images.githubusercontent.com/65980474/114260093-c0006300-99a0-11eb-8ba8-7618715b0c45.png">
