### PR TITLE
fix entering packets in es

### DIFF
--- a/ptest/usb_session.py
+++ b/ptest/usb_session.py
@@ -445,7 +445,7 @@ class USBSession(object):
             value = jsonObj[field]
             data=json.dumps({
             field: value,
-                "time": str(datetime.datetime.now().isoformat())
+                "time.downlink_recieved": str(datetime.datetime.now().isoformat())
             })
             res = self.es.index(index='statefield_report_'+str(self.radio_imei), doc_type='report', body=data)
             if not res['result'] == 'created':

--- a/tlm/email_processor.py
+++ b/tlm/email_processor.py
@@ -78,7 +78,7 @@ class IridiumEmailProcessor(object):
             # If the attachment is a json string, then return the json
             # as a python dictionary
             data=json.loads(str(payload.decode('utf8').rstrip("\x00")))
-            data["time"]=str(datetime.now().isoformat())
+            data["time.downlink_recieved"]=str(datetime.now().isoformat())
         else:
             # Run downlink parser and return json
             f=open("data.sbd", "wb")
@@ -89,7 +89,7 @@ class IridiumEmailProcessor(object):
             data = json.loads(self.console.readline().rstrip())
             if data is not None:
                 data=data["data"]
-                data["time"]=str(datetime.now().isoformat())
+                data["time.downlink_recieved"]=str(datetime.now().isoformat())
             os.remove("data.sbd")
 
         return data
@@ -207,7 +207,7 @@ class IridiumEmailProcessor(object):
             "mtmsn":self.mtmsn, 
             "confirmation-mtmsn": self.confirmation_mtmsn,
             "send-uplinks": self.send_uplinks,
-            "time": str(datetime.now().isoformat())
+            "time.downlink_recieved": str(datetime.now().isoformat())
         })
 
         # Index iridium report in elasticsearch

--- a/tlm/webservice.py
+++ b/tlm/webservice.py
@@ -34,7 +34,7 @@ def index_sf_report():
     imei=sf_report["imei"]
     data=json.dumps({
         sf_report["field"]: sf_report["value"],
-        "time": str(datetime.now().isoformat())
+        "time.downlink_recieved": str(datetime.now().isoformat())
     })
 
     #index statefield report in elasticsearch
@@ -62,7 +62,7 @@ def search_es():
         },
         "sort": [
             {
-                "time": {
+                "time.downlink_recieved": {
                     "order": "desc"
                 }
             }


### PR DESCRIPTION
# Fix Entering Packets in ES

### Summary of changes
- Whenever we add something to elastic search, we add a "time" field so that we have a record fo when we entered the packet in ElasticSearch
- Since we have some state fields named like "time.[...]", Elasticsearch doesn't know how to resolve this. So, we changed "time" to "time.downlink_recieved"
