### PR TITLE
Clean PTest Terminal of Auto Telem Prints

### DIFF
--- a/ptest/usb_session.py
+++ b/ptest/usb_session.py
@@ -155,7 +155,7 @@ class USBSession(object):
                 elif 'telem' in data:
                     logline = f"[{data['time']}] Received requested telemetry from spacecraft.\n"
                     logline += data['telem']
-                    print("\n" + logline)
+                    # print("\n" + logline)
                     self.logger.put(logline, add_time = False)
                     #log data to a timestamped file
                     telem_bytes = data['telem'].split(r'\x')
@@ -438,7 +438,7 @@ class USBSession(object):
 
         jsonObj = self.parsetelem()
         if not isinstance(jsonObj, dict):
-            print(f"Error parsing telemetry on {self.device_name}")            
+            # print(f"Error parsing telemetry on {self.device_name}")            
             return False
         failed = False
         for field in jsonObj:

--- a/src/fsw/FCCode/QuakeManager.cpp
+++ b/src/fsw/FCCode/QuakeManager.cpp
@@ -243,7 +243,7 @@ void QuakeManager::copy_next_packet()
     // load the current 70 bytes of the buffer
     qct.set_downlink_msg(mo_buffer_copy + (packet_size * mo_idx), packet_size);
     #if !defined(FLIGHT) && defined(AUTOTELEM)
-    printf(debug_severity::error, "Attempting to Dump Telemetry\n");
+    // printf(debug_severity::error, "Attempting to Dump Telemetry\n");
     dump_debug_telemetry(mo_buffer_copy + (packet_size * mo_idx), packet_size);
     #endif
     assert(max_snapshot_size / packet_size != 0);


### PR DESCRIPTION
# Clean PTest Terminal of Auto Telem Prints

Fixes really annoying prints of telemetry data that really shouldn't be on master.

### Summary of changes
- comment out prints in usb_session
- comment out prints in QuakeManager

Commenting the above out just in case people need it in the future for debugging telemetry functionality.
