### PR TITLE
Remove Angular Rate Overrides from PTest Cases

### DIFF
--- a/ptest/cases/mission/standby.py
+++ b/ptest/cases/mission/standby.py
@@ -2,8 +2,6 @@ from ..base import DualSatCase, SingleSatCase, PSimCase
 from ..utils import TestCaseFailure
 from .utils import log_fc_data, log_psim_data
 
-import lin
-
 
 class SingleSatStandbyCase(SingleSatCase, PSimCase):
 
@@ -11,7 +9,6 @@ class SingleSatStandbyCase(SingleSatCase, PSimCase):
         super(SingleSatStandbyCase, self).__init__(*args, **kwargs)
 
         self.psim_configs += ["truth/standby"]
-        self.psim_config_overrides["truth.leader.attitude.w"] = lin.Vector3([0.01,0.0711,-0.01])
         self.initial_state = "standby"
         self.skip_deployment_wait = True
 
@@ -35,8 +32,6 @@ class DualSatStandbyCase(DualSatCase, PSimCase):
         super(DualSatStandbyCase, self).__init__(*args, **kwargs)
 
         self.psim_configs += ["truth/standby"]
-        self.psim_config_overrides["truth.leader.attitude.w"] = lin.Vector3([0.01,0.0711,-0.01])
-        self.psim_config_overrides["truth.follower.attitude.w"] = lin.Vector3([0.01,0.0711,-0.01])
         self.leader_initial_state = "standby"
         self.follower_initial_state = "standby"
         self.leader_skip_deployment_wait = True

--- a/ptest/cases/piksi_fault_handler.py
+++ b/ptest/cases/piksi_fault_handler.py
@@ -1,14 +1,11 @@
 from .base import SingleSatCase, PSimCase
 from .utils import FSWEnum, Enums, TestCaseFailure
-from psim.sims import SingleAttitudeOrbitGnc
-import lin
 
 class PiksiFaultHandler(SingleSatCase, PSimCase):
     def __init__(self, *args, **kwargs):
         super(PiksiFaultHandler, self).__init__(*args, **kwargs)
         self.initial_state = "standby"
         self.psim_configs += ["truth/standby"]
-        self.psim_config_overrides["truth.leader.attitude.w"] = lin.Vector3([0.01,0.071,-0.01])
         self.debug_to_console = True
 
         self.initial_state = "standby"

--- a/ptest/cases/prop_fault_handler.py
+++ b/ptest/cases/prop_fault_handler.py
@@ -1,6 +1,5 @@
 from .base import SingleSatCase, PSimCase
 from .utils import Enums, TestCaseFailure
-import lin
 
 # pio run -e fsw_native_leader
 # python -m ptest runsim -c ptest/configs/ci.json -t PropFaultHandler
@@ -11,7 +10,6 @@ class PropFaultHandler(SingleSatCase, PSimCase):
         self.initial_state = "standby"
         self.skip_deployment_wait = True
         self.psim_configs += ["truth/standby"]
-        self.psim_config_overrides["truth.leader.attitude.w"] = lin.Vector3([0.01,0.0711,-0.01])
 
         self.tank2_pressure = 12.0
         self.tank2_temp = 25.0

--- a/ptest/cases/safehold_reboot.py
+++ b/ptest/cases/safehold_reboot.py
@@ -1,13 +1,11 @@
 from .base import SingleSatCase, PSimCase
 from .utils import FSWEnum, Enums, TestCaseFailure
-import lin 
 
 class SafeholdReboot(SingleSatCase, PSimCase):
     def __init__(self, *args, **kwargs):
         super(SafeholdReboot, self).__init__(*args, **kwargs)
         self.initial_state = "standby"
         self.psim_configs += ['truth/standby']
-        self.psim_config_overrides["truth.leader.attitude.w"] = lin.Vector3([0.01,0.0711,-0.01])
 
     def post_boot(self):
         self.ws('fault_handler.enabled', True)

--- a/ptest/cases/simple_fault_handlers.py
+++ b/ptest/cases/simple_fault_handlers.py
@@ -1,13 +1,11 @@
 from .base import SingleSatCase, PSimCase
 from .utils import FSWEnum, Enums, TestCaseFailure
-import lin
 
 class ADCSWheelFaultHandler(SingleSatCase, PSimCase):
     def __init__(self, *args, **kwargs):
         super(ADCSWheelFaultHandler, self).__init__(*args, **kwargs)
         self.initial_state = "standby"
         self.psim_configs += ['truth/standby']
-        self.psim_config_overrides["truth.leader.attitude.w"] = lin.Vector3([0.01,0.0711,-0.01])
 
     def post_boot(self):
         self.ws("fault_handler.enabled", True)
@@ -51,7 +49,6 @@ class LowBattFaultHandler(SingleSatCase, PSimCase):
     def __init__(self, *args, **kwargs):
         super(LowBattFaultHandler, self).__init__(*args, **kwargs)
         self.psim_configs += ["truth/standby"]
-        self.psim_config_overrides["truth.leader.attitude.w"] = lin.Vector3([0.01,0.0711,-0.01])
         self.initial_state = "standby"
 
     def post_boot(self):


### PR DESCRIPTION
Closes #720.

We actually have CI to test these things now so everything should be alright!

Future PRs should no longer need to override PSim initial conditions to make it into standby quickly.