### PR TITLE
Fix USB Session Synchronization

### DIFF
--- a/.github/workflows/hootl.yml
+++ b/.github/workflows/hootl.yml
@@ -31,21 +31,18 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.13.1'
+    - uses: bazelbuild/setup-bazelisk@v1
+    - name: Mount bazel cache
+      uses: actions/cache@v2
+      with:
+        path: "~/.cache/bazel"
+        key: bazel
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         platformio update
-
-    - name: Install Bazel
-      run: |
-        sudo apt install apt-transport-https curl gnupg
-        curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
-        sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
-        echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-        sudo apt upgrade
-        sudo apt install bazel
 
     - name: Install Psim
       run: |

--- a/.github/workflows/hootl.yml
+++ b/.github/workflows/hootl.yml
@@ -40,10 +40,11 @@ jobs:
 
     - name: Install Bazel
       run: |
-        sudo apt install curl gnupg
+        sudo apt install apt-transport-https curl gnupg
         curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
         sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
         echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
+        sudo apt upgrade
         sudo apt install bazel
 
     - name: Install Psim

--- a/ptest/http_cmd.py
+++ b/ptest/http_cmd.py
@@ -151,39 +151,3 @@ def create_radio_session_endpoint(radio_session, queue):
         return "Successfully sent telemetry to Iridium"
 
     return app
-
-def create_usb_session_endpoint(usb_session):
-    app = Flask(__name__)
-    app.logger.disabled = True
-    app.config["usb_session"] = usb_session
-
-    app.config["SWAGGER"]={"title": "PAN State Session Command Endpoint", "uiversion": 2}
-    swagger=Swagger(app, config=swagger_config)
-
-    @app.route("/send-telem", methods=["POST"])
-    @swag_from("endpoint_configs/usb_session/send-telem.yml")
-    def send_telem():
-        uplink=request.get_json()
-
-        # Create an uplink packet
-        fields, vals=list(), list()
-        for field_val in uplink:
-            fields.append(field_val["field"])
-            vals.append(field_val["value"])
-
-        uplink_console = app.config["uplink_console"]
-        success = uplink_console.create_uplink(fields, vals, "http_uplink.sbd", "http_uplink.json") and os.path.exists("http_uplink.sbd")
-
-        # If the uplink packet is successfully created, then send it to the Flight Computer
-        if not success: return "Unable to send telemetry"
-        success = usb_session.send_uplink("uplink.sbd")
-
-        # Get rid of uplink files/cleanup
-        os.remove("http_uplink.sbd")
-        os.remove("http_uplink.json")
-
-        if success:
-            return "Successfully sent telemetry to State Session"
-        return "Unable to send telemetry"
-
-    return app


### PR DESCRIPTION
Fixes #557 
Fixes #743

### Summary of changes

- Update synchronization primitives around USB Session read and write state.
- USB session's HTTP endpoint was also removed to try and reduce the general overhead of `ptest`.

There were two main issues with the previous implementation. First, the Python `queue.Queue` doesn't guarantee a FIFO behavior in terms of the threads that are blocking on the queue (spurious wakeups), just FIFO behavior with the items in the queue:

https://github.com/python/cpython/blob/196983563d05e32d2dcf217e955a919f9e0c25e1/Lib/queue.py#L154-L183

Secondly, we have no synchronization in terms of when a physical request was actually sent over and who blocked on the requests queue:

https://github.com/pathfinder-for-autonomous-navigation/FlightSoftware/blob/a0078703eb03bf9aef6e5ffaf8f27ff56ec188b2/ptest/usb_session.py#L204-L214

https://github.com/pathfinder-for-autonomous-navigation/FlightSoftware/blob/a0078703eb03bf9aef6e5ffaf8f27ff56ec188b2/ptest/usb_session.py#L226-L231

https://github.com/pathfinder-for-autonomous-navigation/FlightSoftware/blob/a0078703eb03bf9aef6e5ffaf8f27ff56ec188b2/ptest/usb_session.py#L272-L279

To fix this, the new design works as follows:

1. A read state or write state function will grab the requests lock that ensure they're the only thread adding requests to the queue.
2. The requests are actually added to the queue.
3. The thread with the requests queue will then grad the device lock to send the request over the serial line.
4. Both the requests and device lock are released.
5. The thread reading or writing state will block on each requests `data` property which will happen until the thread processing incoming has fulfilled the request.

### Testing

Threading thing are inherently difficult to test but HOOTL worked very well on much system spamming read state commands alongside a `psim` simulation. Hopefully that means the issues are cleared up!
