### PR TITLE
Fancy Testcase Flight Controllers

### DIFF
--- a/ptest/cases/base/dual_sat_case.py
+++ b/ptest/cases/base/dual_sat_case.py
@@ -1,13 +1,7 @@
 from ...data_consumers import Logger
-import time
-import math
-import threading
-import traceback
 from ..utils import Enums, TestCaseFailure, suppress_faults
-import psim # the actual python psim repo
-import lin
-import datetime
-from .ptest_case import PTestCase
+from .ptest_case import FancyFlightController, PTestCase
+
 
 class DualSatCase(PTestCase):
     """Base class for all HOOTL and HITL testcases involving two satellites.
@@ -29,7 +23,9 @@ class DualSatCase(PTestCase):
     def populate_devices(self, devices, radios):
         if devices:
             self.flight_controller_leader = devices["FlightControllerLeader"]
+            self.leader = FancyFlightController(self.flight_controller_leader, self.logger)
             self.flight_controller_follower = devices["FlightControllerFollower"]
+            self.follower = FancyFlightController(self.flight_controller_follower, self.logger)
             self.devices = [self.flight_controller_leader, self.flight_controller_follower]
         if "FlightControllerLeaderRadio" in radios:
             self.radio_leader = radios["FlightControllerLeaderRadio"]
@@ -125,33 +121,3 @@ class DualSatCase(PTestCase):
             #    device.scrape_uplink()
             if device.enable_auto_dbtelem:
                 device.dbtelem()
-
-    @property
-    def mission_state_leader(self):
-        return Enums.mission_states[int(self.flight_controller_leader.read_state("pan.state"))]
-
-    @property
-    def mission_state_follower(self):
-        return Enums.mission_states[int(self.flight_controller_follower.read_state("pan.state"))]
-
-    @mission_state_leader.setter
-    def mission_state_leader(self, state):
-        self.flight_controller_leader.write_state("pan.state", int(Enums.mission_states[state]))
-
-    @mission_state_follower.setter
-    def mission_state_follower(self, state):
-        self.flight_controller_follower.write_state("pan.state", int(Enums.mission_states[state]))
-
-    def read_state_leader(self, string_state):
-        return self.flight_controller_leader.read_state(string_state)
-
-    def write_state_leader(self, string_state, state_value):
-        self.flight_controller_leader.write_state(string_state, state_value)
-        return self.flight_controller_leader.read_state(string_state)
-
-    def read_state_follower(self, string_state):
-        return self.flight_controller_follower.read_state(string_state)
-
-    def write_state_follower(self, string_state, state_value):
-        self.flight_controller_follower.write_state(string_state, state_value)
-        return self.flight_controller_follower.read_state(string_state)

--- a/ptest/cases/base/single_sat_case.py
+++ b/ptest/cases/base/single_sat_case.py
@@ -116,7 +116,7 @@ class SingleSatCase(PTestCase):
         return self.leader.rs(name, print=print)
 
     def print_rs(self, name):
-        return self.leader.rs(self, name)
+        return self.leader.rs(name, print=True)
 
     def ws(self, name, val, print=False):
         self.leader.ws(name, val, print=print)

--- a/ptest/cases/gomspace_checkout_case.py
+++ b/ptest/cases/gomspace_checkout_case.py
@@ -3,8 +3,19 @@
 from .base import SingleSatCase
 from .utils import Enums, TestCaseFailure
 
+# DO NOT USE AS A REFRENCE TO WRITE OTHER PTEST CASES
+#
+# This testcase is basically a dinosaur among the other testcases and using many
+# features that are considered "deprecated".
 
 class GomspaceCheckoutCase(SingleSatCase):
+
+    def read_state(self, string_state):
+        return self.flight_controller.read_state(string_state)
+
+    def write_state(self, string_state, state_value):
+        self.flight_controller.write_state(string_state, state_value)
+        return self.read_state(string_state)
 
     def str_to_bool(self, string):
         if string == "true":

--- a/ptest/cases/prop_state_machine_case.py
+++ b/ptest/cases/prop_state_machine_case.py
@@ -2,9 +2,22 @@ from .base import SingleSatCase
 from .utils import Enums, TestCaseFailure
 import time
 
+# DO NOT USE AS A REFRENCE TO WRITE OTHER PTEST CASES
+#
+# This testcase is basically a dinosaur among the other testcases and using many
+# features that are considered "deprecated".
+
 # pio run -e fsw_native_leader
 # python -m ptest runsim -c ptest/configs/fc_only_native.json -t PropStateMachineCase
 class PropStateMachineCase(SingleSatCase):
+
+    def read_state(self, string_state):
+        return self.flight_controller.read_state(string_state)
+
+    def write_state(self, string_state, state_value):
+        self.flight_controller.write_state(string_state, state_value)
+        return self.read_state(string_state)
+
     def post_boot(self):
         self.mission_state = 'manual'
         self.cycle()

--- a/ptest/cases/quake_power_cycling.py
+++ b/ptest/cases/quake_power_cycling.py
@@ -71,11 +71,11 @@ class QuakePowerCycling(SingleSatCase):
             raise TestCaseFailure("QuakeFaultHandler failed to power cycle the output channel.")
        
     def diagnostics(self):
-        self.read_state("radio.state")
-        self.read_state("qfh.state")
-        self.read_state("radio.last_comms_ccno")
-        self.read_state("gomspace.power_cycle_output3_cmd")
-        self.read_state("pan.state")
+        self.rs("radio.state")
+        self.rs("qfh.state")
+        self.rs("radio.last_comms_ccno")
+        self.rs("gomspace.power_cycle_output3_cmd")
+        self.rs("pan.state")
 
     def run(self):
         # The satellite has been in a blackout since startup. Cycle count starts at 1.


### PR DESCRIPTION

### Summary of changes

This is really just a quality of life thing. Essentially, this PR attempts to centralize the way in which we interact with a flight controller across dual and single sat cases. Much like `psim`, there is now a `self.leader: FancyFlightController` in all test cases and a `self.follower: FancyFlightController` in dual sat cases.

The PR is pretty straightforward, but now we have the follower abilities:

```
self.[leader|follower].rs(<field>, print=[True|False])
self.[leader|follower].ws(<field>, <value>, print=[True|False])
```

along with the `mission_state` property (we could add more of these and even come up with a fancy decorate to generate them for us!)

Most changes are intended to be backwards compatible; however, some write state functions were removed that did a `ws` immediately followed by a read to reduce test case overhead.