### PR TITLE
Add Sleep on Desktop Platforms

### DIFF
--- a/src/fsw/FCCode/TimedControlTask.hpp
+++ b/src/fsw/FCCode/TimedControlTask.hpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <chrono>
 #include <time.h>
+#include <unistd.h>
 #else
 #include <Arduino.h>
 #endif
@@ -94,6 +95,8 @@ class TimedControlTaskBase {
       while(duration_to_us(get_system_time() - start) < delta_t) {
         #ifndef DESKTOP
           delayMicroseconds(10);
+        #else
+          usleep(10);
         #endif
       }
     }


### PR DESCRIPTION
HOOTLs no longer pin a core to 100% for each fsw binary. Can someone verify this still builds on Mac?

I also suspect this could help with performance issues on Linux. Most likely, the scheduler was demoting the fsw binary as a long running program without many interrupts/system calls.