### PR TITLE
Add Infinite Loop to the End of the Prop Filling Script

### DIFF
--- a/src/prep/FillingSequence_with_gomspace_pings.cpp
+++ b/src/prep/FillingSequence_with_gomspace_pings.cpp
@@ -272,5 +272,5 @@ void loop() {
 
    Serial.println("al fin \n");
 
-   exit(0);
+   while (1) delay(100);
 }


### PR DESCRIPTION
Per the title. This prevents the script from restarting when it ends because `exit(0)` doesn't do anything on Arduino.