### PR TITLE
Gnc upgrade

### DIFF
--- a/src/fsw/FCCode/OrbitController.cpp
+++ b/src/fsw/FCCode/OrbitController.cpp
@@ -88,10 +88,12 @@ void OrbitController::execute() {
     // If we don't have all the information we need, don't calculate a firing
     if (!time_valid_fp->get() || !orbit_valid_fp->get() || !rel_orbit_valid_fp->get() ||
             !attitude_estimator_valid_fp->get()) {
-        sched_valve1_f.set(0);
-        sched_valve2_f.set(0);
-        sched_valve3_f.set(0);
-        sched_valve4_f.set(0);
+        return;
+    }
+    
+    // Don't fire unless we're in follower and follower close approach.
+    mission_state_t mission_state = static_cast<mission_state_t>(mission_state_fp->get());
+    if (!(mission_state == mission_state_t::follower || mission_state == mission_state_t::follower_close_approach)){
         return;
     }
 
@@ -137,42 +139,24 @@ void OrbitController::execute() {
         prop_cycles_until_firing_fp->set(time_till_firing_cc);
     }
 
-    // Check if the satellite is around a firing point and the prop system is ready to fire
-    // and if the time and orbit data is valid
-    if ( time_till_firing_cc < 20 && static_cast<prop_state_t>(prop_state_fp->get()) == prop_state_t::await_firing) {
+    // Collect the output of the PD controller and get the needed impulse
+    lin::Vector3d J_ecef = calculate_impulse(t, r, v, dr_smoothed, dv_smoothed);
 
-        // Collect the output of the PD controller and get the needed impulse
-        lin::Vector3d J_ecef = calculate_impulse(t, r, v, dr_smoothed, dv_smoothed);
+    // Save J_ecef to statefield
+    J_ecef_f.set(J_ecef);
 
-        // Save J_ecef to statefield
-        J_ecef_f.set(J_ecef);
+    // Transform the impulse from ecef frame to the eci frame
+    lin::Vector4d q_eci_ecef;
+    gnc::utl::quat_conj(q_ecef_eci, q_eci_ecef);
+    lin::Vector3d J_eci;
+    gnc::utl::rotate_frame(q_eci_ecef, J_ecef, J_eci);
 
-        // Transform the impulse from ecef frame to the eci frame
-        lin::Vector4d q_eci_ecef;
-        gnc::utl::quat_conj(q_ecef_eci, q_eci_ecef);
-        lin::Vector3d J_eci;
-        gnc::utl::rotate_frame(q_eci_ecef, J_ecef, J_eci);
+    // Transform the impulse from eci frame to the body frame of the spacecraft
+    lin::Vector4f q_body_eci = q_body_eci_fp->get();
+    lin::Vector3d J_body;
+    gnc::utl::rotate_frame(lin::cast<double>(q_body_eci).eval(), J_eci, J_body);
 
-        // Transform the impulse from eci frame to the body frame of the spacecraft
-        lin::Vector4f q_body_eci = q_body_eci_fp->get();
-        lin::Vector3d J_body;
-        gnc::utl::rotate_frame(lin::cast<double>(q_body_eci).eval(), J_eci, J_body);
-
-        // Communicate desired impulse to the prop controller.
-        mission_state_t mission_state = static_cast<mission_state_t>(mission_state_fp->get());
-        if (mission_state == mission_state_t::follower || mission_state == mission_state_t::follower_close_approach) {
-            schedule_valves(J_body);
-        }
-        else{
-            // 0 out schedules
-            schedule_valves(lin::zeros<lin::Vector3d>());
-        }
-    }
-    else{
-        // 0 out schedules
-        schedule_valves(lin::zeros<lin::Vector3d>());
-    }
-
+    schedule_valves(J_body);
 }
 
 double OrbitController::time_till_node(double theta, const lin::Vector3d &pos, const lin::Vector3d &vel) {

--- a/src/fsw/FCCode/OrbitController.cpp
+++ b/src/fsw/FCCode/OrbitController.cpp
@@ -133,7 +133,7 @@ void OrbitController::execute() {
     double time_till_firing_cc = time_till_firing * 1000 / PAN::control_cycle_time_ms;
 
     // Schedule the valves for firing soon if the prop system is idle
-    if (time_till_firing_cc <= (prop_min_cycles_needed() + 10) && static_cast<prop_state_t>(prop_state_fp->get()) == prop_state_t::idle) {
+    if (time_till_firing_cc <= (prop_min_cycles_needed() + 10) && static_cast<prop_state_t>(prop_state_fp->get()) == prop_state_t::idle) { // should we keep the <=
         prop_cycles_until_firing_fp->set(time_till_firing_cc);
     }
 
@@ -163,7 +163,10 @@ void OrbitController::execute() {
         if (mission_state == mission_state_t::follower || mission_state == mission_state_t::follower_close_approach) {
             schedule_valves(J_body);
         }
-
+    }
+    else{
+        // 0 out schedules
+        schedule_valves(lin::zeros<lin::Vector3d>());
     }
 
 }

--- a/src/fsw/FCCode/OrbitController.cpp
+++ b/src/fsw/FCCode/OrbitController.cpp
@@ -163,6 +163,10 @@ void OrbitController::execute() {
         if (mission_state == mission_state_t::follower || mission_state == mission_state_t::follower_close_approach) {
             schedule_valves(J_body);
         }
+        else{
+            // 0 out schedules
+            schedule_valves(lin::zeros<lin::Vector3d>());
+        }
     }
     else{
         // 0 out schedules

--- a/src/fsw/FCCode/PropController.cpp
+++ b/src/fsw/FCCode/PropController.cpp
@@ -390,7 +390,7 @@ bool PropState_Pressurizing::can_enter() const
 
     // min_cycles_needed is actually an upper bound on how long we could need
     bool is_time_to_pressurize = (
-            (controller->cycles_until_firing.get() <= controller->min_cycles_needed())
+            (controller->cycles_until_firing.get() <= controller->min_cycles_needed() - 1)
         );
 
     return ((was_await_pressurizing || was_idle) && is_time_to_pressurize && is_schedule_valid && is_functional);

--- a/src/fsw/FCCode/PropController.cpp
+++ b/src/fsw/FCCode/PropController.cpp
@@ -281,12 +281,9 @@ bool PropState_AwaitPressurizing::can_enter() const
 {
     bool was_idle = controller->check_current_state(prop_state_t::idle);
     bool is_schedule_valid = controller->validate_schedule();
-    // enter await pressurizing if orbit controller requests a firing.
-    bool requested =
-        controller->cycles_until_firing.get() > 0;
     bool is_functional = PropulsionSystem.is_functional();
 
-    return (was_idle && is_schedule_valid && is_functional && requested);
+    return (was_idle && is_schedule_valid && is_functional);
 }
 
 void PropState_AwaitPressurizing::enter()
@@ -394,7 +391,6 @@ bool PropState_Pressurizing::can_enter() const
     // min_cycles_needed is actually an upper bound on how long we could need
     bool is_time_to_pressurize = (
             (controller->cycles_until_firing.get() <= controller->min_cycles_needed())
-            && (controller->cycles_until_firing.get() > 0)
         );
 
     return ((was_await_pressurizing || was_idle) && is_time_to_pressurize && is_schedule_valid && is_functional);

--- a/src/fsw/FCCode/PropController.cpp
+++ b/src/fsw/FCCode/PropController.cpp
@@ -282,11 +282,11 @@ bool PropState_AwaitPressurizing::can_enter() const
     bool was_idle = controller->check_current_state(prop_state_t::idle);
     bool is_schedule_valid = controller->validate_schedule();
     // Enter Await Pressurizing rather than Pressurizing if we have MORE than enough time
-    bool more_than_enough_time =
-        controller->cycles_until_firing.get() >= controller->min_cycles_needed();
+    // bool more_than_enough_time =
+    //     controller->cycles_until_firing.get() >= controller->min_cycles_needed();
     bool is_functional = PropulsionSystem.is_functional();
 
-    return (was_idle && is_schedule_valid && more_than_enough_time && is_functional);
+    return (was_idle && is_schedule_valid && is_functional);
 }
 
 void PropState_AwaitPressurizing::enter()
@@ -391,15 +391,14 @@ bool PropState_Pressurizing::can_enter() const
     bool was_idle = controller->check_current_state(prop_state_t::idle);
     bool is_functional = PropulsionSystem.is_functional();
 
-    // It is time to pressurize when we have min_cycles_needed - 1 cycles left
-    bool is_time_to_pressurize =
-        controller->cycles_until_firing.get() == controller->min_cycles_needed() - 1;
-    
-    return ((was_await_pressurizing || was_idle) && is_time_to_pressurize && is_schedule_valid && is_functional);
+    return ((was_await_pressurizing || was_idle) && is_schedule_valid && is_functional);
 }
 
 prop_state_t PropState_Pressurizing::evaluate()
 {
+    // if our desired time to fire has already passed, early exit to idle to try again
+    if (controller->cycles_until_firing.get() == 0)
+        return prop_state_t::idle;
     if (controller->can_enter_state(prop_state_t::handling_fault))
         return prop_state_t::handling_fault;
     return ActionCycleOpenClose::evaluate();

--- a/src/fsw/FCCode/PropController.cpp
+++ b/src/fsw/FCCode/PropController.cpp
@@ -399,10 +399,14 @@ bool PropState_Pressurizing::can_enter() const
 prop_state_t PropState_Pressurizing::evaluate()
 {
     // if our desired time to fire has already passed, early exit to idle to try again
-    if (controller->cycles_until_firing.get() == 0)
+    if (controller->cycles_until_firing.get() == 0){
+        PropulsionSystem.reset();
         return prop_state_t::idle;
-    if (controller->can_enter_state(prop_state_t::handling_fault))
+    }
+    if (controller->can_enter_state(prop_state_t::handling_fault)){
+        PropulsionSystem.reset();
         return prop_state_t::handling_fault;
+    }
     return ActionCycleOpenClose::evaluate();
 }
 
@@ -414,6 +418,7 @@ prop_state_t PropState_Pressurizing::handle_out_of_cycles()
     if (controller->pressurize_fail_fault_f.is_faulted())
     {
         DD("[!] --> transitioning to handling_fault\n");
+        PropulsionSystem.reset();
         return prop_state_t::handling_fault;
     }
     // Fault is suppressed

--- a/src/fsw/FCCode/PropController.cpp
+++ b/src/fsw/FCCode/PropController.cpp
@@ -399,7 +399,7 @@ bool PropState_Pressurizing::can_enter() const
 prop_state_t PropState_Pressurizing::evaluate()
 {
     // if our desired time to fire has already passed, early exit to idle to try again
-    if (controller->cycles_until_firing.get() == 0){
+    if (controller->cycles_until_firing.get() <= 1){
         PropulsionSystem.reset();
         return prop_state_t::idle;
     }

--- a/test/test_fsw_prop_controller/test_prop_controller.cpp
+++ b/test/test_fsw_prop_controller/test_prop_controller.cpp
@@ -164,10 +164,11 @@ void test_pressurizing_to_idle_out_of_cycles(){
     TestFixture tf;
     PropulsionSystem.set_is_functional(true);
     tf.set_state(prop_state_t::idle);
-    tf.set_schedule(200, 400, 12, 800, 2*tf.pc->min_cycles_needed());
+    tf.set_schedule(200, 400, 12, 800, tf.pc->min_cycles_needed()/2);
     tf.step();
-
-
+    check_state(prop_state_t::pressurizing);
+    tf.execute_until_state_change(); // assume we dont hit target pressure
+    check_state(prop_state_t::idle);
 }
 
 void test_pressurize_to_firing()

--- a/test/test_fsw_prop_controller/test_prop_controller.cpp
+++ b/test/test_fsw_prop_controller/test_prop_controller.cpp
@@ -160,6 +160,16 @@ void test_pressurize_to_firing_helper(bool functional = true)
     else check_state(prop_state_t::idle);
 }
 
+void test_pressurizing_to_idle_out_of_cycles(){
+    TestFixture tf;
+    PropulsionSystem.set_is_functional(true);
+    tf.set_state(prop_state_t::idle);
+    tf.set_schedule(200, 400, 12, 800, 2*tf.pc->min_cycles_needed());
+    tf.step();
+
+
+}
+
 void test_pressurize_to_firing()
 {
     test_pressurize_to_firing_helper();
@@ -474,6 +484,7 @@ int test_prop_controller()
     RUN_TEST(test_idle_to_await_pressurize);
     RUN_TEST(test_await_pressurize_to_pressurize);
     RUN_TEST(test_pressurize_to_await_firing);
+    RUN_TEST(test_pressurizing_to_idle_out_of_cycles);
     RUN_TEST(test_pressurize_to_firing);
     RUN_TEST(test_pressurizing);
     RUN_TEST(test_pressurize_fail);


### PR DESCRIPTION
On this ticket:
- when we shouldn't fire do not zero out any valves, this lets us maintain manual control of the valves, even when the orbit controller doesn't autonomously request a valve firing
- move the condition of only firing when in follower or follower close approach as an early return statement, if we are not in those two states. This prevents us from scheduling a firing or setting a valve schedule when we are not in those states
- Ensure all transitions out of Pressurizing have a reset call to ensure all valves are closed
- Allow entry into the pressurizing state if the firing is closer than the minimum required number of cycles to "ensure" we hit target pressure
- Allow the pressurizing state to exit to idle if the firing is too close (possibly meaning we don't hit target pressure).
- Add test case to test the above