### PR TITLE
Node generator

### DIFF
--- a/src/flow_data.cpp
+++ b/src/flow_data.cpp
@@ -30,7 +30,7 @@ const std::vector<DownlinkProducer::FlowData> PAN::flow_data = {
 {23, false, {"adcs_monitor.ssa_voltage0", "adcs_monitor.ssa_voltage1", "adcs_monitor.ssa_voltage2", "adcs_monitor.ssa_voltage3", "adcs_monitor.ssa_voltage4", "adcs_monitor.ssa_voltage5", "adcs_monitor.ssa_voltage6", "adcs_monitor.ssa_voltage7", "adcs_monitor.ssa_voltage8", "adcs_monitor.ssa_voltage9"}},
 {24, false, {"adcs_monitor.ssa_voltage10", "adcs_monitor.ssa_voltage11", "adcs_monitor.ssa_voltage12", "adcs_monitor.ssa_voltage13", "adcs_monitor.ssa_voltage14", "adcs_monitor.ssa_voltage15", "adcs_monitor.ssa_voltage16", "adcs_monitor.ssa_voltage17", "adcs_monitor.ssa_voltage18", "adcs_monitor.ssa_voltage19"}},
 {25, true, {"docksys.docked"}},
-{26, true, {"orbit.control.valve1", "orbit.control.valve2", "orbit.control.valve3", "orbit.control.valve4", "orbit.control.J_ecef", "orbit.control.alpha"}},
+{26, true, {"orbit.control.valve1", "orbit.control.valve2", "orbit.control.valve3", "orbit.control.valve4", "orbit.control.J_ecef", "orbit.control.alpha", "orbit.control.num_near_field_nodes"}},
 {27, false, {"prop.cycles_until_firing", "prop.sched_intertank1", "prop.sched_intertank2"}},
 {28, false, {"adcs_cmd.rwa_speed_cmd", "adcs_cmd.rwa_torque_cmd", "adcs_cmd.mtr_cmd"}},
 {29, false, {"timing.adcs_commander.avg_wait", "timing.adcs_commander.num_lates", "timing.adcs_controller.avg_wait", "timing.adcs_controller.num_lates", "timing.estimators.avg_wait", "timing.estimators.num_lates", "timing.adcs_monitor.avg_wait", "timing.adcs_monitor.num_lates", "timing.attitude_controller.avg_wait", "timing.attitude_controller.num_lates", "timing.clock_ct.avg_wait", "timing.clock_ct.num_lates", "timing.dcdc_ct.avg_wait", "timing.dcdc_ct.num_lates", "timing.debug.avg_wait", "timing.debug.num_lates"}},

--- a/src/flow_data.csv
+++ b/src/flow_data.csv
@@ -32,7 +32,7 @@ ADCS Sun Sensor Voltages 1,FALSE,adcs_monitor.ssa_voltage0,adcs_monitor.ssa_volt
 ADCS Sun Sensor Voltages 2,FALSE,adcs_monitor.ssa_voltage10,adcs_monitor.ssa_voltage11,adcs_monitor.ssa_voltage12,adcs_monitor.ssa_voltage13,adcs_monitor.ssa_voltage14,adcs_monitor.ssa_voltage15,adcs_monitor.ssa_voltage16,adcs_monitor.ssa_voltage17,adcs_monitor.ssa_voltage18,adcs_monitor.ssa_voltage19,,,,,,,,,,,,,,,,
 Docking core information,TRUE,docksys.docked,,,,,,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,
-OrbitController,TRUE,orbit.control.valve1,orbit.control.valve2,orbit.control.valve3,orbit.control.valve4,orbit.control.J_ecef,orbit.control.alpha,,,,,,,,,,,,,,,,,,,,
+OrbitController,TRUE,orbit.control.valve1,orbit.control.valve2,orbit.control.valve3,orbit.control.valve4,orbit.control.J_ecef,orbit.control.alpha,orbit.control.num_near_field_nodes,,,,,,,,,,,,,,,,,,,,
 Prop Controls,FALSE,prop.cycles_until_firing,prop.sched_intertank1,prop.sched_intertank2,,,,,,,,,,,,,,,,,,,
 ADCS Control Vectors,FALSE,adcs_cmd.rwa_speed_cmd,adcs_cmd.rwa_torque_cmd,adcs_cmd.mtr_cmd,,,,,,,,,,,,,,,,,,,,,,,
 Timing Data 1,FALSE,timing.adcs_commander.avg_wait,timing.adcs_commander.num_lates,timing.adcs_controller.avg_wait,timing.adcs_controller.num_lates,timing.estimators.avg_wait,timing.estimators.num_lates,timing.adcs_monitor.avg_wait,timing.adcs_monitor.num_lates,timing.attitude_controller.avg_wait,timing.attitude_controller.num_lates,timing.clock_ct.avg_wait,timing.clock_ct.num_lates,timing.dcdc_ct.avg_wait,timing.dcdc_ct.num_lates,timing.debug.avg_wait,timing.debug.num_lates,,,,,,,,,,

--- a/src/fsw/FCCode/OrbitController.cpp
+++ b/src/fsw/FCCode/OrbitController.cpp
@@ -10,12 +10,7 @@ const constexpr double OrbitController::valve_time_lin_reg_intercept;
 // Firing nodes
 constexpr double pi = gnc::constant::pi;
 static constexpr std::array<double, 3> firing_nodes_far = {pi/3, pi, -pi/3};
-static constexpr std::array<double, 18> firing_nodes_near = {pi/18, pi/6, pi*(5/18), pi*(7/18), pi/2, pi*(11/18), 
-                                pi*(13/18), pi*(5/6), pi*(17/18), -pi*(17/18),
-                                -pi*(5/6), -pi*(13/18), -pi*(11/18), -pi/2,
-                                -pi*(7/18), -pi*(5/18), -pi/6, -pi/18};
-
-static constexpr auto gain_factor = static_cast<double>(firing_nodes_near.size()) / firing_nodes_far.size();
+static std::array<double, 360> firing_nodes_near;
 
 OrbitController::OrbitController(StateFieldRegistry &r) : 
     TimedControlTask<void>(r, "orbit_control_ct"),
@@ -45,12 +40,14 @@ OrbitController::OrbitController(StateFieldRegistry &r) :
     add_writable_field(sched_valve4_f);
     add_writable_field(J_ecef_f);
     add_writable_field(alpha_f);
+    add_writable_field(near_field_nodes_f);
     sched_valve1_f.set(0);
     sched_valve2_f.set(0);
     sched_valve3_f.set(0);
     sched_valve4_f.set(0);
     J_ecef_f.set(lin::zeros<lin::Vector3d>());
     alpha_f.set(0.4);
+    near_field_nodes_f.set(180);
     dr_smoothed = lin::nans<lin::Vector3d>();
     dv_smoothed = lin::nans<lin::Vector3d>();
 }
@@ -193,7 +190,7 @@ double OrbitController::time_till_node(double theta, const lin::Vector3d &pos, c
         }
         return min_time;
     };
-
+    node_generator(firing_nodes_near, near_field_nodes_f.get());
     return (rel_orbit_state == static_cast<unsigned char>(rel_orbit_state_t::estimating)) ? 
             next_node(firing_nodes_near) : next_node(firing_nodes_far);
 }
@@ -216,6 +213,7 @@ lin::Vector3d OrbitController::calculate_impulse(double t, const lin::Vector3d &
     data.d = gnc::constant::K_d;
     data.energy_gain = gnc::constant::K_e;   // Energy gain                   (J)
     data.h_gain = gnc::constant::K_h;        // Angular momentum gain         (kg m^2/sec)
+    static auto gain_factor = static_cast<double>(near_field_nodes_f.get()) / firing_nodes_far.size();
     
     if (rel_orbit_state==static_cast<unsigned char>(rel_orbit_state_t::estimating)) {
         data.p /= gain_factor;  
@@ -284,4 +282,16 @@ unsigned int OrbitController::prop_min_cycles_needed() {
                (ctrl_cycles_per_filling_period_fp->get() +
                 ctrl_cycles_per_cooling_period_fp->get()) +
            4;
+}
+
+void OrbitController::node_generator(std::array<double, 360> &firing_nodes_near, unsigned int num_nodes){
+    for (int i = 0; i < firing_nodes_near.size(); i++) {
+        firing_nodes_near[i] = (PI/90) * i;
+        if (firing_nodes_near[i] > PI) {
+            firing_nodes_near[i] = firing_nodes_near[i]- 2*PI;
+        }
+        if (i > num_nodes - 1) {
+            firing_nodes_near[i] = NULL;
+        }
+    }
 }

--- a/src/fsw/FCCode/OrbitController.cpp
+++ b/src/fsw/FCCode/OrbitController.cpp
@@ -283,7 +283,7 @@ unsigned int OrbitController::prop_min_cycles_needed() {
 }
 
 void OrbitController::node_generator(std::array<double, 360> &firing_nodes_near, unsigned int num_nodes){
-    for (int i = 0; i < firing_nodes_near.size(); i++) {
+    for (unsigned int i = 0; i < firing_nodes_near.size(); i++) {
         firing_nodes_near[i] = (pi/90) * i;
         if (firing_nodes_near[i] > pi) {
             firing_nodes_near[i] = firing_nodes_near[i]- 2*pi;

--- a/src/fsw/FCCode/OrbitController.cpp
+++ b/src/fsw/FCCode/OrbitController.cpp
@@ -35,7 +35,8 @@ OrbitController::OrbitController(StateFieldRegistry &r) :
     sched_valve3_f("orbit.control.valve3", Serializer<unsigned int>(1000)),
     sched_valve4_f("orbit.control.valve4", Serializer<unsigned int>(1000)),
     J_ecef_f("orbit.control.J_ecef", Serializer<lin::Vector3d>(0,0.025,10)),
-    alpha_f("orbit.control.alpha", Serializer<double>(0,1,10))
+    alpha_f("orbit.control.alpha", Serializer<double>(0,1,10)),
+    near_field_nodes_f("orbit.control.near_field_nodes", Serializer<unsigned int>(300))
 
 {
     add_writable_field(sched_valve1_f);
@@ -72,6 +73,8 @@ void OrbitController::execute() {
     lin::Vector3d dv = baseline_vel_fp->get();
 
     if (rel_orbit_valid_fp->get()) {
+        unsigned int near_field_nodes = near_field_nodes_f.get();
+        
         if (!lin::all(lin::isfinite(dr_smoothed))) {
             dr_smoothed = dr;
         } else {

--- a/src/fsw/FCCode/OrbitController.cpp
+++ b/src/fsw/FCCode/OrbitController.cpp
@@ -291,7 +291,7 @@ void OrbitController::node_generator(std::array<double, 360> &firing_nodes_near,
             firing_nodes_near[i] = firing_nodes_near[i]- 2*PI;
         }
         if (i > num_nodes - 1) {
-            firing_nodes_near[i] = NULL;
+            firing_nodes_near[i] = 0;
         }
     }
 }

--- a/src/fsw/FCCode/OrbitController.cpp
+++ b/src/fsw/FCCode/OrbitController.cpp
@@ -31,7 +31,7 @@ OrbitController::OrbitController(StateFieldRegistry &r) :
     sched_valve4_f("orbit.control.valve4", Serializer<unsigned int>(1000)),
     J_ecef_f("orbit.control.J_ecef", Serializer<lin::Vector3d>(0,0.025,10)),
     alpha_f("orbit.control.alpha", Serializer<double>(0,1,10)),
-    near_field_nodes_f("orbit.control.near_field_nodes", Serializer<unsigned int>(300))
+    num_near_field_nodes_f("orbit.control.num_near_field_nodes", Serializer<unsigned int>(300))
 
 {
     add_writable_field(sched_valve1_f);
@@ -40,14 +40,14 @@ OrbitController::OrbitController(StateFieldRegistry &r) :
     add_writable_field(sched_valve4_f);
     add_writable_field(J_ecef_f);
     add_writable_field(alpha_f);
-    add_writable_field(near_field_nodes_f);
+    add_writable_field(num_near_field_nodes_f);
     sched_valve1_f.set(0);
     sched_valve2_f.set(0);
     sched_valve3_f.set(0);
     sched_valve4_f.set(0);
     J_ecef_f.set(lin::zeros<lin::Vector3d>());
     alpha_f.set(0.4);
-    near_field_nodes_f.set(180);
+    num_near_field_nodes_f.set(180);
     dr_smoothed = lin::nans<lin::Vector3d>();
     dv_smoothed = lin::nans<lin::Vector3d>();
 }
@@ -70,8 +70,6 @@ void OrbitController::execute() {
     lin::Vector3d dv = baseline_vel_fp->get();
 
     if (rel_orbit_valid_fp->get()) {
-        unsigned int near_field_nodes = near_field_nodes_f.get();
-        
         if (!lin::all(lin::isfinite(dr_smoothed))) {
             dr_smoothed = dr;
         } else {
@@ -190,7 +188,7 @@ double OrbitController::time_till_node(double theta, const lin::Vector3d &pos, c
         }
         return min_time;
     };
-    node_generator(firing_nodes_near, near_field_nodes_f.get());
+    node_generator(firing_nodes_near, num_near_field_nodes_f.get());
     return (rel_orbit_state == static_cast<unsigned char>(rel_orbit_state_t::estimating)) ? 
             next_node(firing_nodes_near) : next_node(firing_nodes_far);
 }
@@ -213,7 +211,7 @@ lin::Vector3d OrbitController::calculate_impulse(double t, const lin::Vector3d &
     data.d = gnc::constant::K_d;
     data.energy_gain = gnc::constant::K_e;   // Energy gain                   (J)
     data.h_gain = gnc::constant::K_h;        // Angular momentum gain         (kg m^2/sec)
-    static auto gain_factor = static_cast<double>(near_field_nodes_f.get()) / firing_nodes_far.size();
+    static auto gain_factor = static_cast<double>(num_near_field_nodes_f.get()) / firing_nodes_far.size();
     
     if (rel_orbit_state==static_cast<unsigned char>(rel_orbit_state_t::estimating)) {
         data.p /= gain_factor;  
@@ -286,9 +284,9 @@ unsigned int OrbitController::prop_min_cycles_needed() {
 
 void OrbitController::node_generator(std::array<double, 360> &firing_nodes_near, unsigned int num_nodes){
     for (int i = 0; i < firing_nodes_near.size(); i++) {
-        firing_nodes_near[i] = (PI/90) * i;
-        if (firing_nodes_near[i] > PI) {
-            firing_nodes_near[i] = firing_nodes_near[i]- 2*PI;
+        firing_nodes_near[i] = (pi/90) * i;
+        if (firing_nodes_near[i] > pi) {
+            firing_nodes_near[i] = firing_nodes_near[i]- 2*pi;
         }
         if (i > num_nodes - 1) {
             firing_nodes_near[i] = 0;

--- a/src/fsw/FCCode/OrbitController.hpp
+++ b/src/fsw/FCCode/OrbitController.hpp
@@ -105,6 +105,6 @@ public:
     WritableStateField<unsigned int> sched_valve4_f;
     WritableStateField<lin::Vector3d> J_ecef_f;
     WritableStateField<double> alpha_f;
-    WritableStateField<unsigned int> near_field_nodes_f;
+    WritableStateField<unsigned int> num_near_field_nodes_f;
 
 };

--- a/src/fsw/FCCode/OrbitController.hpp
+++ b/src/fsw/FCCode/OrbitController.hpp
@@ -72,6 +72,14 @@ public:
     WritableStateField<unsigned int>* ctrl_cycles_per_filling_period_fp;
     WritableStateField<unsigned int>* ctrl_cycles_per_cooling_period_fp;
 
+    /**
+     * @brief Function takes in the number of firing nodes and mutates the
+     * array to contain the firing nodes for near field. The size of 360
+     * is chosen to be large enough to allow a firing every degree (~15 secs)
+     */
+
+    void node_generator(std::array<double, 360> &nodes_list, unsigned int num_nodes);
+
     // Input statefields for time, position, velocity, and baseline
     // position/velocity in ECEF
     const InternalStateField<double>* const time_fp;

--- a/src/fsw/FCCode/OrbitController.hpp
+++ b/src/fsw/FCCode/OrbitController.hpp
@@ -97,5 +97,6 @@ public:
     WritableStateField<unsigned int> sched_valve4_f;
     WritableStateField<lin::Vector3d> J_ecef_f;
     WritableStateField<double> alpha_f;
+    WritableStateField<unsigned int> near_field_nodes_f;
 
 };

--- a/telemetry
+++ b/telemetry
@@ -1737,6 +1737,14 @@
             "type": "double",
             "writable": true
         },
+        "orbit.control.num_near_field_nodes": {
+            "bitsize": 9,
+            "flow_id": 26,
+            "max": 300,
+            "min": 0,
+            "type": "unsigned int",
+            "writable": true
+        },
         "orbit.control.valve1": {
             "bitsize": 10,
             "flow_id": 26,
@@ -3229,7 +3237,8 @@
                 "orbit.control.valve3",
                 "orbit.control.valve4",
                 "orbit.control.J_ecef",
-                "orbit.control.alpha"
+                "orbit.control.alpha",
+                "orbit.control.num_near_field_nodes"
             ],
             "id": 26,
             "priority": 25


### PR DESCRIPTION
# Node Generator

### Summary of changes
- Allows near field firing frequency to be controlled from the ground
- Adds node_generator function which generates a list of firing nodes
- Closes issue #799 
- Since the size of node list is 360, we can fire no faster than every 15 seconds, if we want to fire more frequently, the node list size needs to increase

### Telemetry
- Adds num_near_field_nodes as a writable state field

