### PR TITLE
Disable mst

### DIFF
--- a/src/fsw/FCCode/DownlinkProducer.cpp
+++ b/src/fsw/FCCode/DownlinkProducer.cpp
@@ -3,9 +3,9 @@
 #include <set>
 
 DownlinkProducer::DownlinkProducer(StateFieldRegistry& r) : TimedControlTask<void>(r, "downlink_ct"),
+                                 disable_mission_state_change_f("downlink.disable_mission_state_telem", Serializer<bool>()),
                                  snapshot_ptr_f("downlink.ptr"),
-                                 snapshot_size_bytes_f("downlink.snap_size"),
-                                 disable_mission_state_change_f("downlink.disable_mission_state_telem", Serializer<bool>())
+                                 snapshot_size_bytes_f("downlink.snap_size")
 {
     cycle_count_fp = find_readable_field<unsigned int>("pan.cycle_no", __FILE__, __LINE__);
 
@@ -135,7 +135,7 @@ static void add_bits_to_downlink_frame(const bit_array& field_bits,
 }
 
 void DownlinkProducer::execute() {
-    if (disable_mission_state_change_f.get()) {
+    if (!disable_mission_state_change_f.get()) {
         check_mission_state_change();
     }
     current_state = mission_state_fp->get();

--- a/src/fsw/FCCode/DownlinkProducer.hpp
+++ b/src/fsw/FCCode/DownlinkProducer.hpp
@@ -183,6 +183,11 @@ class DownlinkProducer : public TimedControlTask<void> {
      */
     void reset_flows();
 
+    /**
+     * @brief Statefield used to disable changing mission state telemetry flow order
+     */
+    WritableStateField<bool> disable_mission_state_change_f;
+
   protected:
     /** @brief Pointer to cycle count. */
     ReadableStateField<unsigned int>* cycle_count_fp;
@@ -212,11 +217,6 @@ class DownlinkProducer : public TimedControlTask<void> {
      * @brief Statefield used to toggle flow's active status. Default is 0 (no flow can have an id of 0)
      */
     std::unique_ptr<WritableStateField<unsigned char>> toggle_flow_id_fp;
-
-    /**
-     * @brief Statefield used to disable changing mission state telemetry flow order
-     */
-    WritableStateField<bool> disable_mission_state_change_f;
 
     const WritableStateField<unsigned char>* mission_state_fp;
 

--- a/src/fsw/FCCode/DownlinkProducer.hpp
+++ b/src/fsw/FCCode/DownlinkProducer.hpp
@@ -213,6 +213,11 @@ class DownlinkProducer : public TimedControlTask<void> {
      */
     std::unique_ptr<WritableStateField<unsigned char>> toggle_flow_id_fp;
 
+    /**
+     * @brief Statefield used to disable changing mission state telemetry flow order
+     */
+    WritableStateField<bool> disable_mission_state_change_f;
+
     const WritableStateField<unsigned char>* mission_state_fp;
 
     unsigned char current_state;


### PR DESCRIPTION
# Add disable flag for changing the flow order based on mission state

### Summary of changes
- Added a disable flag so that we don't reorder flows when the mission state changes

### Testing
Added a unit test checking that the flow order doesn't change when changing mission state