### PR TITLE
Remove Old Calls to scrape_uplink in Single Sat Case

### DIFF
--- a/ptest/cases/base/single_sat_case.py
+++ b/ptest/cases/base/single_sat_case.py
@@ -107,8 +107,6 @@ class SingleSatCase(PTestCase):
 
         super(SingleSatCase, self).cycle()
 
-        if self.flight_controller.scrape:
-            self.flight_controller.scrape_uplink()
         if self.flight_controller.enable_auto_dbtelem:
             self.flight_controller.dbtelem()
 


### PR DESCRIPTION
# Remove Old Calls to scrape_uplink

Fixes #840 

### Summary of changes
- Remove old scrape uplink calls to fix imap errors on single sat cases with autotelem as it is also outdated (we now call scrape_uplink in thread off of usb_session)
