### PR TITLE
831 recreate

### DIFF
--- a/src/fsw/FCCode/Estimators/TimeEstimator.cpp
+++ b/src/fsw/FCCode/Estimators/TimeEstimator.cpp
@@ -33,6 +33,7 @@ TimeEstimator::TimeEstimator(StateFieldRegistry &registry)
 
     time_valid_f.set(false);
     time_reset_cmd_f.set(false);
+    time_gps_f.set(time_gps_f.get() + PAN::control_cycle_time_ns);
 }
 
 void TimeEstimator::execute()
@@ -62,7 +63,8 @@ void TimeEstimator::execute()
 
         // No valid time reading from Piksi
         default:
-            time_gps_f.set(time_gps_f.get() + PAN::control_cycle_time_ns);
+            // time_gps_f.set(time_gps_f.get() + PAN::control_cycle_time_ns);
+            // time_gps_f.set(time_gps_f.get());
             break;
     }
 

--- a/src/fsw/FCCode/FieldCreatorTask.hpp
+++ b/src/fsw/FCCode/FieldCreatorTask.hpp
@@ -18,12 +18,12 @@
 class FieldCreatorTask : public ControlTask<void>
 {
 public:
-  ReadableStateField<unsigned char> bootcount_f;
+  ReadableStateField<unsigned int> bootcount_f;
   ReadableStateField<bool> cursed_bit_f;
 
   FieldCreatorTask(StateFieldRegistry &r)
       : ControlTask<void>(r),
-        bootcount_f("pan.bootcount", Serializer<unsigned char>(), 100),
+        bootcount_f("pan.bootcount", Serializer<unsigned int>(0xffffffff), 100),
         cursed_bit_f("cursed", Serializer<bool>())
   {
     add_readable_field(bootcount_f);

--- a/src/fsw/FCCode/FieldCreatorTask.hpp
+++ b/src/fsw/FCCode/FieldCreatorTask.hpp
@@ -23,7 +23,7 @@ public:
 
   FieldCreatorTask(StateFieldRegistry &r)
       : ControlTask<void>(r),
-        bootcount_f("pan.bootcount", Serializer<unsigned int>(0xffffffff), 100),
+        bootcount_f("pan.bootcount", Serializer<unsigned int>(0x7fffffff), 100),
         cursed_bit_f("cursed", Serializer<bool>())
   {
     add_readable_field(bootcount_f);

--- a/src/fsw/FCCode/MissionManager.cpp
+++ b/src/fsw/FCCode/MissionManager.cpp
@@ -55,7 +55,7 @@ MissionManager::MissionManager(StateFieldRegistry &registry)
     add_internal_field(enter_close_approach_ccno_f);
     add_writable_field(kill_switch_f);
 
-    bootcount_fp = find_readable_field<unsigned char>("pan.bootcount", __FILE__, __LINE__);
+    bootcount_fp = find_readable_field<unsigned int>("pan.bootcount", __FILE__, __LINE__);
 
     static_cast<MainFaultHandler *>(main_fault_handler.get())->init();
 

--- a/src/fsw/FCCode/MissionManager.hpp
+++ b/src/fsw/FCCode/MissionManager.hpp
@@ -227,7 +227,7 @@ protected:
     /**
      * @brief Number of times the satellite has booted
      */
-    ReadableStateField<unsigned char> *bootcount_fp;
+    ReadableStateField<unsigned int> *bootcount_fp;
 
     /**
      * @brief True if Gomspace is not supplying power to port that Piksi is connected to (OUT-1)


### PR DESCRIPTION
Before opening the PR, think: 
- Is this PR bulletproof? Can I think of no ways to improve this PR beyond its current state?
- Is the PR short enough to ensure a quick but thorough review, but long enough to represent a complete feature? For large state machines, let's try opening PRs for only a few states at a time.

If the answer to either of these questions is "no", refactor your code and open your PR when the answer to both questions is "yes".

--------------------------

# PR Title

Fixes #. (Optional; sometimes PRs don't have an associated ticket)

### Summary of changes
- 
- 
-

If it applies, take a chance to describe offshoot work or TODOs that are a part of your PR.

### Testing
Describe your unit and functional testing. The testing should be at a level appropriate to demonstrate that your feature is sufficiently tested.

If you've got HITL or HOOTL run logs, the logs should go under the "Pull Request HITL Logs" [folder](https://cornellprod-my.sharepoint.com/personal/saa243_cornell_edu/_layouts/15/onedrive.aspx?id=%2Fpersonal%2Fsaa243%5Fcornell%5Fedu%2FDocuments%2FOAAN%20Team%20Folder%2FSubsystems%2FSoftware%2FPull%20Request%20HITL%20Testing%20Logs) on the OneDrive. Create a new subfolder with the # of this PR and put your items there. Note: the logs can be found after ptesting at `ptest/logs` (pick the appropriately dated folder for the log containing a successful run.)

The logs can be read via the ptest standalone plotter utility. See ptest/ for more details.

If your update does not require significant testing, argue why, or if you're deferring testing to another PR, create an issue ticket for the deferral and link it.

### Constants
Describe any important diffs to the `constants` file in the root level of the repository. Ensure that any constants you added to the code successfully made it into the `constants` file. If not, wrap the missing constants with `TRACKED_CONSTANT` macros and fix `constants_reporter.py` if necessary.

### Telemetry
Describe any important diffs to the `telemetry` file in the root level of the repository. Ensure that any telemetry you added to the code successfully made it into the `telemetry` file.

Also, take the opportunity to add the telemetry into the appropriate flows in src/flow_data.csv.

### Documentation Evidence
Post to ReadTheDocs, or
- Argue that your inline documentation is sufficient.
- Create a issue ticket deferring the documentation task.
