### PR TITLE
Cursed testing viewing

### DIFF
--- a/ptest/cases/dcdc_checkout_case.py
+++ b/ptest/cases/dcdc_checkout_case.py
@@ -12,6 +12,8 @@ class DCDCCheckoutCase(SingleSatCase):
         self.__prop = None
         self.__disable_command = None
         self.__reset_command = None
+        
+        self.check_initial_state = False
 
     @property
     def adcs_command(self) -> bool:
@@ -108,6 +110,12 @@ class DCDCCheckoutCase(SingleSatCase):
         if not self.adcs_command or not self.adcs or \
                 not self.prop_command or not self.prop or self.reset_command:
             self.abort("Failed to reset the DCDCs.")
+
+    def post_boot(self):
+        '''Keep it in the manual state which does not auotnomously control DCDCs'''
+        self.ws('pan.state', Enums.mission_states['manual'])
+        self.ws('pan.deployment_elapsed', 0)
+        self.cycle()
 
     def run(self):
         self.cycle()

--- a/ptest/cases/flow_inspect.py
+++ b/ptest/cases/flow_inspect.py
@@ -40,11 +40,11 @@ class FlowInspect(SingleSatCase):
         print(parsetelem_results)
         parsetelem_results ={k:str_to_val(v) for k,v in parsetelem_results.items()}
         
-        # print('PARSETELEM RESULTS: ')
-        # print(parsetelem_results)
+        print('PARSETELEM RESULTS: ')
+        print(parsetelem_results)
      
-        # print('RS RESULTS: ')       
-        # print(rs_results)
+        print('RS RESULTS: ')       
+        print(rs_results)
 
         diffs = [sf_name for sf_name in self.all_state_fields if parsetelem_results[sf_name] != rs_results[sf_name]]
         

--- a/ptest/usb_session.py
+++ b/ptest/usb_session.py
@@ -445,7 +445,8 @@ class USBSession(object):
         telem_json_data = json.loads(line)
 
         if telem_json_data is not None:
-                telem_json_data = telem_json_data["data"]
+            print(telem_json_data["metadata"]["log"])
+            telem_json_data = telem_json_data["data"]
         return telem_json_data
 
     def dbtelem(self):

--- a/ptest/usb_session.py
+++ b/ptest/usb_session.py
@@ -451,6 +451,7 @@ class USBSession(object):
 
         if telem_json_data is not None:
             print(telem_json_data["metadata"]["log"])
+            print("FLOWINSPECT ret "+ telem_json_data["metadata"]["packet_str"])
             telem_json_data = telem_json_data["data"]
         return telem_json_data
 

--- a/ptest/usb_session.py
+++ b/ptest/usb_session.py
@@ -157,6 +157,7 @@ class USBSession(object):
         '''
 
         while self.running_logger:
+            bit_debug_value_msgs = []
             try:
                 # Read line coming from device and parse it
                 if self.console.inWaiting() > 0:
@@ -172,6 +173,10 @@ class USBSession(object):
                     # The logline represents a debugging message created by Flight Software. Report the message to the logger.
                     logline = f"[{data['time']}] ({data['svrty']}) {data['msg']}"
                     self.logger.put(logline, add_time = False)
+
+                    if "FLOWINSPECT" in data['msg']:
+                        bit_debug_value_msgs.append(data['msg'])
+                        print(data['msg'])
 
                     # If we want debug to go to the console
                     if self.debug_to_console:

--- a/src/common/debug_console.cpp
+++ b/src/common/debug_console.cpp
@@ -122,7 +122,7 @@ void debug_console::_print_json_msg(severity_t severity, const char* msg) {
 void debug_console::_print_error_state_field(char const *field_name,
         state_cmd_mode_t mode, state_field_error_t error_code) {
 #ifdef DESKTOP
-    DynamicJsonDocument doc(500);
+    DynamicJsonDocument doc(10000);
 #else
     StaticJsonDocument<200> doc;
 #endif
@@ -184,7 +184,7 @@ void debug_console::close() {
 void debug_console::printf(severity_t severity, const char* fmt, ...) {
     if (!is_open) return;
 
-    char buf[100];
+    char buf[1000];
     va_list args;
     va_start(args, fmt);
     vsnprintf(buf, sizeof(buf), fmt, args);

--- a/src/fsw/FCCode/DownlinkProducer.cpp
+++ b/src/fsw/FCCode/DownlinkProducer.cpp
@@ -79,17 +79,23 @@ static void add_bits_to_downlink_frame(const bit_array& field_bits,
     const size_t field_size = field_bits.size();
 
     std::string field;
-    for (int i = 0; i < field_size; i++)
-        field += field_bits[i] ? "1" : "0";
 
-    debug_console::printf(debug_severity::info, "Printing bits at position %d: %s", packet_offset, field.c_str());
+    bit_array field_bits_1s = bit_array(field_size);
+
+    for (int i = 0; i < field_size; i++)
+    {
+        field_bits_1s[i] = 1;
+        field += field_bits_1s[i] ? "1" : "0";
+    }
+
+    debug_console::printf(debug_severity::info, "FLOWINSPECT Printing bits at position %d: %s", packet_offset, field.c_str());
 
     const int field_overflow = (field_size + packet_offset)
         - DownlinkProducer::num_bits_in_packet; // Number of bits in field that run past the packet end
 
     if(field_overflow <= 0) {
         // Contiguously write field to snapshot buffer
-        field_bits.to_string(snapshot_ptr, downlink_frame_offset);
+        field_bits_1s.to_string(snapshot_ptr, downlink_frame_offset);
         downlink_frame_offset += field_size;
         packet_offset += field_size;
     }
@@ -98,7 +104,7 @@ static void add_bits_to_downlink_frame(const bit_array& field_bits,
         const int x = field_size - field_overflow; // # of bits in field that don't overrun a packet
 
         // Copy first part of field
-        field_bits.to_string(snapshot_ptr, downlink_frame_offset, 0, x);
+        field_bits_1s.to_string(snapshot_ptr, downlink_frame_offset, 0, x);
         downlink_frame_offset += x;
         packet_offset = 0;
 
@@ -109,7 +115,7 @@ static void add_bits_to_downlink_frame(const bit_array& field_bits,
         packet_offset += 1;
 
         // Copy the rest of the field
-        field_bits.to_string(snapshot_ptr, downlink_frame_offset, x, field_size);
+        field_bits_1s.to_string(snapshot_ptr, downlink_frame_offset, x, field_size);
         downlink_frame_offset += field_overflow;
         packet_offset += field_overflow;
     }

--- a/src/fsw/FCCode/DownlinkProducer.cpp
+++ b/src/fsw/FCCode/DownlinkProducer.cpp
@@ -77,6 +77,13 @@ static void add_bits_to_downlink_frame(const bit_array& field_bits,
                                        size_t& downlink_frame_offset)
 {
     const size_t field_size = field_bits.size();
+
+    std::string field;
+    for (int i = 0; i < field_size; i++)
+        field += field_bits[i] ? "1" : "0";
+
+    debug_console::printf(debug_severity::info, "Printing bits at position %d: %s", packet_offset, field.c_str());
+
     const int field_overflow = (field_size + packet_offset)
         - DownlinkProducer::num_bits_in_packet; // Number of bits in field that run past the packet end
 
@@ -128,9 +135,11 @@ void DownlinkProducer::execute() {
     // Add control cycle count to the initial packet
     cycle_count_fp->serialize();
     const bit_array& cycle_count_bits = cycle_count_fp->get_bit_array();
+    debug_console::printf(debug_severity::info, "cycle count");
     add_bits_to_downlink_frame(cycle_count_bits, snapshot_ptr, packet_offset,
             downlink_frame_offset);
 
+    int id = 1;
     for(auto const& flow : flows) {
         if (!flow.is_active) continue;
 
@@ -146,6 +155,7 @@ void DownlinkProducer::execute() {
             if (event) {
                 // Event should be serialized when it is signaled
                 const bit_array& event_bits = event->get_bit_array();
+                debug_console::printf(debug_severity::info, "flow id: %d, size %d", id, flow.get_packet_size());
                 add_bits_to_downlink_frame(event_bits, snapshot_ptr, packet_offset,
                     downlink_frame_offset);
             }
@@ -156,6 +166,7 @@ void DownlinkProducer::execute() {
                     downlink_frame_offset);
             }
         }
+        id++;
     }
 
     // If there are bits remaining in the last character of the downlink frame,
@@ -233,8 +244,12 @@ size_t DownlinkProducer::Flow::get_packet_size() const {
     size_t packet_size = 0;
     packet_size += id_sr.bitsize();
 
+    debug_console::printf(debug_severity::info, "New packet");
     for(auto const& field: field_list) {
         packet_size += field->get_bit_array().size();
+        size_t field_size = field->get_bit_array().size();
+        debug_console::printf(debug_severity::info, "bitsize of field: %d", field_size);
+        packet_size += field_size;
     }
 
     return packet_size;

--- a/src/fsw/FCCode/DownlinkProducer.cpp
+++ b/src/fsw/FCCode/DownlinkProducer.cpp
@@ -245,8 +245,8 @@ size_t DownlinkProducer::Flow::get_packet_size() const {
     packet_size += id_sr.bitsize();
 
     debug_console::printf(debug_severity::info, "New packet");
-    for(auto const& field: field_list) {
-        packet_size += field->get_bit_array().size();
+    for (auto const &field : field_list)
+    {
         size_t field_size = field->get_bit_array().size();
         debug_console::printf(debug_severity::info, "bitsize of field: %d", field_size);
         packet_size += field_size;

--- a/src/fsw/FCCode/DownlinkProducer.cpp
+++ b/src/fsw/FCCode/DownlinkProducer.cpp
@@ -172,16 +172,16 @@ void DownlinkProducer::execute() {
                 const bit_array& field_bits = field->get_bit_array();
                 debug_console::printf(debug_severity::info, "FLOWINSPECT flow id: %d, size %d", id, flow.get_packet_size());
 
-                std::string packet_str;
-                for (int j = 0; j < compute_downlink_size(); j++)
-                {
-                    char c = snapshot[j];
-                    for (int i = 7; i >= 0; --i)
-                    {
-                        packet_str += ((c & (1 << i)) ? '1' : '0');
-                    }
-                }
-                debug_console::printf(debug_severity::info, "FLOWINSPECT flow id: %s", packet_str.c_str());
+                // std::string packet_str;
+                // for (int j = 0; j < compute_downlink_size(); j++)
+                // {
+                //     char c = snapshot[j];
+                //     for (int i = 7; i >= 0; --i)
+                //     {
+                //         packet_str += ((c & (1 << i)) ? '1' : '0');
+                //     }
+                // }
+                // debug_console::printf(debug_severity::info, "FLOWINSPECT: %s", packet_str.c_str());
 
                 add_bits_to_downlink_frame(field_bits, snapshot_ptr, packet_offset,
                     downlink_frame_offset);

--- a/src/fsw/FCCode/DownlinkProducer.cpp
+++ b/src/fsw/FCCode/DownlinkProducer.cpp
@@ -112,7 +112,8 @@ static void add_bits_to_downlink_frame(const bit_array& field_bits,
 
         // Mark the header for a new packet
         char& packet_start = snapshot_ptr[(downlink_frame_offset / 70)];
-        packet_start = bit_array::modify_bit(packet_start, 7, 0);
+        debug_console::printf(debug_severity::info, "FLOWINSPECT splitting packet start, d/70 %d %d", packet_start, (downlink_frame_offset / 70));
+        //packet_start = bit_array::modify_bit(packet_start, 7, 0); //cursed
         downlink_frame_offset += 1;
         packet_offset += 1;
 
@@ -163,14 +164,14 @@ void DownlinkProducer::execute() {
             if (event) {
                 // Event should be serialized when it is signaled
                 const bit_array& event_bits = event->get_bit_array();
-                debug_console::printf(debug_severity::info, "FLOWINSPECT event flow id: %d, size %d", id, flow.get_packet_size());
+                //debug_console::printf(debug_severity::info, "FLOWINSPECT event flow id: %d, size %d", id, flow.get_packet_size());
                 add_bits_to_downlink_frame(event_bits, snapshot_ptr, packet_offset,
                     downlink_frame_offset);
             }
             else{
                 field->serialize();
                 const bit_array& field_bits = field->get_bit_array();
-                debug_console::printf(debug_severity::info, "FLOWINSPECT flow id: %d, size %d", id, flow.get_packet_size());
+                //debug_console::printf(debug_severity::info, "FLOWINSPECT flow id: %d, size %d", id, flow.get_packet_size());
 
                 // std::string packet_str;
                 // for (int j = 0; j < compute_downlink_size(); j++)
@@ -181,7 +182,7 @@ void DownlinkProducer::execute() {
                 //         packet_str += ((c & (1 << i)) ? '1' : '0');
                 //     }
                 // }
-                // debug_console::printf(debug_severity::info, "FLOWINSPECT: %s", packet_str.c_str());
+                // debug_console::printf(debug_severity::info, "FLOWINSPECT packet: %s", packet_str.c_str());
 
                 add_bits_to_downlink_frame(field_bits, snapshot_ptr, packet_offset,
                     downlink_frame_offset);
@@ -190,15 +191,16 @@ void DownlinkProducer::execute() {
         id++;
     }
 
-    std::string packet_str;
-    for (int j = 0; j < compute_downlink_size(); j++)
-    {
-        char c = snapshot[j];
-        for (int i = 7; i >= 0; --i)
-        {
-            packet_str += ((c & (1 << i)) ? '1' : '0');
-        }
-    }
+    // std::string packet_str;
+    // for (int j = 0; j < compute_downlink_size(); j++)
+    // {
+    //     char c = snapshot[j];
+    //     for (int i = 7; i >= 0; --i)
+    //     {
+    //         packet_str += ((c & (1 << i)) ? '1' : '0');
+    //     }
+    // }
+    // debug_console::printf(debug_severity::info, "FLOWINSPECT packet: %s", packet_str.c_str()
 
     //BAD 0s at this point
 

--- a/src/fsw/FCCode/DownlinkProducer.cpp
+++ b/src/fsw/FCCode/DownlinkProducer.cpp
@@ -88,14 +88,24 @@ void DownlinkProducer::add_bits_to_downlink_frame(const bit_array &field_bits,
     std::string field;
 
     bit_array field_bits_1s = bit_array(field_size);
-
-    for (size_t i = 0; i < field_size; i++)
-    {
-        field_bits_1s[i] = 1;
-        field += field_bits_1s[i] ? "1" : "0";
+    
+    if(field_size == 62){
+        for (size_t i = 0; i < field_size; i++)
+        {
+            field_bits_1s[i] = 1;
+            field += field_bits_1s[i] ? "1" : "0";
+        }
+    }
+    else{
+        for (size_t i = 0; i < field_size; i++)
+        {
+            field_bits_1s[i] = 1;
+            field += field_bits_1s[i] ? "1" : "0";
+        }
     }
 
-    //debug_console::printf(debug_severity::info, "FLOWINSPECT Printing bits at position %d: %s", packet_offset, field.c_str()); //all 1s this is fine
+    debug_console::printf(debug_severity::info, "FLOWINSPECT Printing bits at position %d: %s", packet_offset, field.c_str()); //all 1s this is fine
+    debug_console::printf(debug_severity::info, "FLOWINSPECT Downlink Offset at position %d", downlink_frame_offset); //all 1s this is fine
 
     const int field_overflow = (field_size + packet_offset) - DownlinkProducer::num_bits_in_packet; // Number of bits in field that run past the packet end
 
@@ -132,7 +142,7 @@ void DownlinkProducer::add_bits_to_downlink_frame(const bit_array &field_bits,
         // Mark the header for a new packet
         char &packet_start = snapshot_ptr[(downlink_frame_offset / 70)];
         debug_console::printf(debug_severity::info, "FLOWINSPECT splitting packet start, d/70 %d %d", packet_start, (downlink_frame_offset / 70));
-        //packet_start = bit_array::modify_bit(packet_start, 7, 0); //cursed
+        packet_start = bit_array::modify_bit(packet_start, 7, 0); //cursed
         downlink_frame_offset += 1;
         packet_offset += 1;
 
@@ -145,7 +155,7 @@ void DownlinkProducer::add_bits_to_downlink_frame(const bit_array &field_bits,
                 packet_str1 += ((c & (1 << i)) ? '1' : '0');
             }
         }
-        debug_console::printf(debug_severity::info, "FLOWINSPECT POST MARK: %s", packet_str.c_str());
+        debug_console::printf(debug_severity::info, "FLOWINSPECT POST MARK: %s", packet_str1.c_str());
 
         // Copy the rest of the field
         field_bits_1s.to_string(snapshot_ptr, downlink_frame_offset, x, field_size);
@@ -161,7 +171,7 @@ void DownlinkProducer::add_bits_to_downlink_frame(const bit_array &field_bits,
                 packet_str2 += ((c & (1 << i)) ? '1' : '0');
             }
         }
-        debug_console::printf(debug_severity::info, "FLOW POST REST: %s", packet_str.c_str());
+        debug_console::printf(debug_severity::info, "FLOW POST REST: %s", packet_str2.c_str());
     }
 }
 
@@ -230,7 +240,8 @@ void DownlinkProducer::execute()
                 //     }
                 // }
                 // debug_console::printf(debug_severity::info, "FLOWINSPECT packet: %s", packet_str.c_str());
-
+                debug_console::printf(debug_severity::info, "field_name %s", field->name());
+                assert(false);
                 add_bits_to_downlink_frame(field_bits, snapshot_ptr, packet_offset,
                                            downlink_frame_offset);
             }
@@ -238,16 +249,16 @@ void DownlinkProducer::execute()
         id++;
     }
 
-    // std::string packet_str;
-    // for (int j = 0; j < compute_downlink_size(); j++)
-    // {
-    //     char c = snapshot[j];
-    //     for (int i = 7; i >= 0; --i)
-    //     {
-    //         packet_str += ((c & (1 << i)) ? '1' : '0');
-    //     }
-    // }
-    // debug_console::printf(debug_severity::info, "FLOWINSPECT packet: %s", packet_str.c_str()
+    std::string packet_str;
+    for (size_t j = 0; j < compute_downlink_size(); j++)
+    {
+        char c = snapshot[j];
+        for (int i = 7; i >= 0; --i)
+        {
+            packet_str += ((c & (1 << i)) ? '1' : '0');
+        }
+    }
+    debug_console::printf(debug_severity::info, "FLOWINSPECT expect packet: %s", packet_str.c_str());
 
     //BAD 0s at this point
 

--- a/src/fsw/FCCode/DownlinkProducer.cpp
+++ b/src/fsw/FCCode/DownlinkProducer.cpp
@@ -240,8 +240,9 @@ void DownlinkProducer::execute()
                 //     }
                 // }
                 // debug_console::printf(debug_severity::info, "FLOWINSPECT packet: %s", packet_str.c_str());
-                debug_console::printf(debug_severity::info, "field_name %s", field->name());
-                assert(false);
+                debug_console::printf(debug_severity::info, "field_name %s\n", field->name().c_str());
+                debug_console::printf(debug_severity::info, "fieldaa_name %d\n", 0);
+
                 add_bits_to_downlink_frame(field_bits, snapshot_ptr, packet_offset,
                                            downlink_frame_offset);
             }

--- a/src/gsw/parsers/src/DownlinkParser.cpp
+++ b/src/gsw/parsers/src/DownlinkParser.cpp
@@ -40,7 +40,8 @@ std::string DownlinkParser::process_downlink_packet(const std::vector<char>& pac
         most_recent_frame = packet;
         ret["metadata"]["error"] = false;
         ret["metadata"]["flow_ids"] = json::array();
-
+        ret["metadata"]["log"] = json::array();
+        
         // Process the downlink frame in four steps.
 
         // Step 1: Manage the downlink frame at a bit level.
@@ -184,6 +185,11 @@ std::string DownlinkParser::process_downlink_packet(const std::vector<char>& pac
 
                     ret["data"][field->name()] = std::string(field->print());
                     frame_bits.erase(frame_bits.begin(), field_end_it);
+
+                    std::string data;
+                    for(int i = 0; i < field->get_bit_array().size(); i++) data += field_bits[i] ? "1" : "0";
+                    ret["metadata"]["log"].push_back("Field " + field->name() + " bits: " + data);
+                    field->set_bit_array(field_bits);
                 }
             }
         }


### PR DESCRIPTION
Before opening the PR, think: 
- Is this PR bulletproof? Can I think of no ways to improve this PR beyond its current state?
- Is the PR short enough to ensure a quick but thorough review, but long enough to represent a complete feature? For large state machines, let's try opening PRs for only a few states at a time.

If the answer to either of these questions is "no", refactor your code and open your PR when the answer to both questions is "yes".

--------------------------

# PR Title

Fixes #. (Optional; sometimes PRs don't have an associated ticket)

### Summary of changes
- 
- 
-

If it applies, take a chance to describe offshoot work or TODOs that are a part of your PR.

### Testing
Describe your unit and functional testing. The testing should be at a level appropriate to demonstrate that your feature is sufficiently tested.

If you've got HITL or HOOTL run logs, the logs should go under the "Pull Request HITL Logs" [folder](https://cornellprod-my.sharepoint.com/personal/saa243_cornell_edu/_layouts/15/onedrive.aspx?id=%2Fpersonal%2Fsaa243%5Fcornell%5Fedu%2FDocuments%2FOAAN%20Team%20Folder%2FSubsystems%2FSoftware%2FPull%20Request%20HITL%20Testing%20Logs) on the OneDrive. Create a new subfolder with the # of this PR and put your items there. Note: the logs can be found after ptesting at `ptest/logs` (pick the appropriately dated folder for the log containing a successful run.)

The logs can be read via the ptest standalone plotter utility. See ptest/ for more details.

If your update does not require significant testing, argue why, or if you're deferring testing to another PR, create an issue ticket for the deferral and link it.

### Constants
Describe any important diffs to the `constants` file in the root level of the repository. Ensure that any constants you added to the code successfully made it into the `constants` file. If not, wrap the missing constants with `TRACKED_CONSTANT` macros and fix `constants_reporter.py` if necessary.

### Telemetry
Describe any important diffs to the `telemetry` file in the root level of the repository. Ensure that any telemetry you added to the code successfully made it into the `telemetry` file.

Also, take the opportunity to add the telemetry into the appropriate flows in src/flow_data.csv.

### Documentation Evidence
Post to ReadTheDocs, or
- Argue that your inline documentation is sufficient.
- Create a issue ticket deferring the documentation task.
