### PR TITLE
Replace swap with triple line tmp swap

### DIFF
--- a/src/fsw/FCCode/DownlinkProducer.cpp
+++ b/src/fsw/FCCode/DownlinkProducer.cpp
@@ -285,12 +285,14 @@ void DownlinkProducer::shift_flow_priorities(unsigned char id1, unsigned char id
     
     if (idx1>idx2) {
         for (size_t i = idx1; i > idx2; i--) {
-            std::swap(flows[i], flows[i-1]);
-        }
+            Flow tmp = flows[i];
+            flows[i] = flows[i-1];
+            flows[i-1] = tmp;        }
     }
     else if (idx2>idx1) {
         for (size_t i = idx1; i < idx2; i++) {
-            std::swap(flows[i],flows[i+1]);
-        }
+            Flow tmp = flows[i];
+            flows[i] = flows[i-1];
+            flows[i-1] = tmp;        }
     }
 }


### PR DESCRIPTION
This is a hotfix to address #862. The problematic command in issue ticket 862 now works on x86 Linux.

## On this PR:
Replace the `std::swap` call with a triple line copy to a temporary variable.